### PR TITLE
Modifications required for CI

### DIFF
--- a/build/gulpfile.vscode.web.js
+++ b/build/gulpfile.vscode.web.js
@@ -19,7 +19,7 @@ const { getProductionDependencies } = require('./lib/dependencies');
 const vfs = require('vinyl-fs');
 const replace = require('gulp-replace');
 const packageJson = require('../package.json');
-const { compileBuildTask } = require('./gulpfile.compile');
+const { compileBuildTask, compileBuildTaskPullRequest } = require('./gulpfile.compile');
 const extensions = require('./lib/extensions');
 
 const REPO_ROOT = path.dirname(__dirname);
@@ -254,10 +254,7 @@ const dashed = (/** @type {string} */ str) => (str ? `-${str}` : ``);
 	gulp.task(vscodeWebTaskCI);
 
 	const vscodeWebTask = task.define(`vscode-web${dashed(minified)}`, task.series(
-		// MEMBRANE: Use this instead of `compileBuildTask` to speed up local builds
-		// by skipping the mangle step (~15min)
-		// compileBuildTaskPullRequest,
-		compileBuildTask,
+		minified ? compileBuildTask : compileBuildTaskPullRequest,
 		vscodeWebTaskCI
 	));
 	gulp.task(vscodeWebTask);

--- a/build/npm/postinstall.js
+++ b/build/npm/postinstall.js
@@ -116,5 +116,7 @@ for (let dir of dirs) {
 	yarnInstall(dir, opts);
 }
 
-cp.execSync('git config pull.rebase merges');
-cp.execSync('git config blame.ignoreRevsFile .git-blame-ignore-revs');
+if (!process.cwd().includes("mnode")) {
+	cp.execSync('git config pull.rebase merges');
+	cp.execSync('git config blame.ignoreRevsFile .git-blame-ignore-revs');
+}

--- a/build/npm/postinstall.js
+++ b/build/npm/postinstall.js
@@ -116,6 +116,7 @@ for (let dir of dirs) {
 	yarnInstall(dir, opts);
 }
 
+// This commands don't play well with being ran inside a submodule so just skip them in that context
 if (!process.cwd().includes("mnode")) {
 	cp.execSync('git config pull.rebase merges');
 	cp.execSync('git config blame.ignoreRevsFile .git-blame-ignore-revs');

--- a/extensions/shared.webpack.config.js
+++ b/extensions/shared.webpack.config.js
@@ -114,7 +114,7 @@ function withBrowserDefaults(/**@type WebpackConfig & { context: string }*/extCo
 		target: 'webworker', // extensions run in a webworker context
 		resolve: {
 			alias: {
-				'./platform/vscode': path.resolve(__dirname, '../../membrane-vscode/ts-plugin/src/platform/browser.ts'),
+				'./platform/vscode': path.resolve(__dirname, '../../ts-plugin/src/platform/browser.ts'),
 			},
 			mainFields: ['browser', 'module', 'main'],
 			extensions: ['.ts', '.js'], // support ts-files and js-files

--- a/extensions/typescript-language-features/web/src/serverHost.ts
+++ b/extensions/typescript-language-features/web/src/serverHost.ts
@@ -11,7 +11,7 @@ import { FileWatcherManager } from './fileWatcherManager';
 import { Logger } from './logging';
 import { PathMapper, looksLikeNodeModules, mapUri } from './pathMapper';
 import { findArgument, hasArgument } from './util/args';
-import membraneTsPlugin from '../../../../../membrane-vscode/ts-plugin/src/index';
+import membraneTsPlugin from '../../../../../ts-plugin/src/index';
 
 type ServerHostWithImport = ts.server.ServerHost & { importPlugin(root: string, moduleName: string): Promise<ts.server.ModuleImportResult> };
 


### PR DESCRIPTION
Link T-650

Now that we're interacting with VSCode primarily as a submodule of `mnode` we need to update the `ts-plugin` reference to just be a sibling of `vscode`. I've also made a change to the build script and added a fix where the postinstall script was causing CI to fail due to some `git config` commands running in the submodule. 

_Note: My commits aren't verified here because I'm pushing them from mk1_