### PR TITLE
Rip out terminals from VSCode

### DIFF
--- a/extensions/shared.webpack.config.js
+++ b/extensions/shared.webpack.config.js
@@ -114,10 +114,12 @@ function withBrowserDefaults(/**@type WebpackConfig & { context: string }*/extCo
 		target: 'webworker', // extensions run in a webworker context
 		resolve: {
 			alias: {
+				// MEMBRANE: ts-plugin is bundled inside typescript-language-features since vscode web doesn't support the
+				// normal typescriptServerPlugins extension setting.
 				'./platform/vscode': path.resolve(__dirname, '../../ts-plugin/src/platform/browser.ts'),
 			},
 			mainFields: ['browser', 'module', 'main'],
-			extensions: ['.ts', '.js'], // support ts-files and js-files
+			extensions: ['.membrane.ts', '.membrane.js', '.ts', '.js'], // support ts-files and js-files
 			fallback: {
 				// 'os': require.resolve('os-browserify'),
 				'events': require.resolve('events/'),

--- a/extensions/shared.webpack.config.js
+++ b/extensions/shared.webpack.config.js
@@ -119,7 +119,7 @@ function withBrowserDefaults(/**@type WebpackConfig & { context: string }*/extCo
 				'./platform/vscode': path.resolve(__dirname, '../../ts-plugin/src/platform/browser.ts'),
 			},
 			mainFields: ['browser', 'module', 'main'],
-			extensions: ['.membrane.ts', '.membrane.js', '.ts', '.js'], // support ts-files and js-files
+			extensions: ['.ts', '.js'], // support ts-files and js-files
 			fallback: {
 				// 'os': require.resolve('os-browserify'),
 				'events': require.resolve('events/'),

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
+		"moduleSuffixes": [".membrane", ""],
 		"removeComments": false,
 		"preserveConstEnums": true,
 		"sourceMap": false,

--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -90,13 +90,6 @@ class SecretStorageProvider implements ISecretStorageProvider {
 	};
 
 	config.secretStorageProvider = new SecretStorageProvider();
-	config.defaultLayout = {
-		force: true,
-		views: [
-			{ id: 'membrane.explorer' },
-			{ id: 'membrane.logs' },
-		]
-	};
 
 	const domElement = document.body;
 	create(domElement, config);

--- a/src/vs/workbench/api/browser/mainThreadTerminalService.membrane.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalService.membrane.ts
@@ -1,0 +1,105 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { MainThreadTerminalServiceShape, MainContext, TerminalLaunchConfig, ExtHostTerminalIdentifier } from 'vs/workbench/api/common/extHost.protocol';
+import { extHostNamedCustomer } from 'vs/workbench/services/extensions/common/extHostCustomers';
+import { IProcessProperty, IProcessReadyWindowsPty, ITerminalOutputMatch, ITerminalOutputMatcher } from 'vs/platform/terminal/common/terminal';
+import { ISerializableEnvironmentDescriptionMap, ISerializableEnvironmentVariableCollection } from 'vs/platform/terminal/common/environmentVariable';
+
+@extHostNamedCustomer(MainContext.MainThreadTerminalService)
+export class MainThreadTerminalService implements MainThreadTerminalServiceShape {
+	constructor() { }
+
+	public dispose(): void { }
+
+	public async $createTerminal(extHostTerminalId: string, launchConfig: TerminalLaunchConfig): Promise<void> {
+		throw new Error('Unsupported');
+	}
+
+	public async $show(id: ExtHostTerminalIdentifier, preserveFocus: boolean): Promise<void> {
+		throw new Error('Unsupported');
+	}
+
+	public async $hide(id: ExtHostTerminalIdentifier): Promise<void> {
+		throw new Error('Unsupported');
+	}
+
+	public async $dispose(id: ExtHostTerminalIdentifier): Promise<void> {
+		throw new Error('Unsupported');
+	}
+
+	public async $sendText(id: ExtHostTerminalIdentifier, text: string, shouldExecute: boolean): Promise<void> {
+		throw new Error('Unsupported');
+	}
+
+	public $sendProcessExit(terminalId: number, exitCode: number | undefined): void {
+		throw new Error('Unsupported');
+	}
+
+	public $startSendingDataEvents(): void {
+		throw new Error('Unsupported');
+	}
+
+	public $stopSendingDataEvents(): void {
+		throw new Error('Unsupported');
+	}
+
+	public $startSendingCommandEvents(): void {
+		throw new Error('Unsupported');
+	}
+
+	public $stopSendingCommandEvents(): void {
+		throw new Error('Unsupported');
+	}
+
+	public $startLinkProvider(): void {
+		throw new Error('Unsupported');
+	}
+
+	public $stopLinkProvider(): void {
+		throw new Error('Unsupported');
+	}
+
+	public $registerProcessSupport(isSupported: boolean): void {
+		// Empty
+	}
+
+	public $registerProfileProvider(id: string, extensionIdentifier: string): void {
+		throw new Error('Unsupported');
+	}
+
+	public $unregisterProfileProvider(id: string): void {
+		throw new Error('Unsupported');
+	}
+
+	public async $registerQuickFixProvider(id: string, extensionId: string): Promise<void> {
+		throw new Error('Unsupported');
+	}
+
+	public $unregisterQuickFixProvider(id: string): void {
+		throw new Error('Unsupported');
+	}
+
+	public $sendProcessData(terminalId: number, data: string): void {
+		throw new Error('Unsupported');
+	}
+
+	public $sendProcessReady(terminalId: number, pid: number, cwd: string, windowsPty: IProcessReadyWindowsPty | undefined): void {
+		throw new Error('Unsupported');
+	}
+
+	public $sendProcessProperty(terminalId: number, property: IProcessProperty<any>): void {
+		throw new Error('Unsupported');
+	}
+
+	$setEnvironmentVariableCollection(extensionIdentifier: string, persistent: boolean, collection: ISerializableEnvironmentVariableCollection | undefined, descriptionMap: ISerializableEnvironmentDescriptionMap): void {
+		throw new Error('Unsupported');
+	}
+}
+
+export function getOutputMatchForLines(lines: string[], outputMatcher: ITerminalOutputMatcher): ITerminalOutputMatch | undefined {
+	const match: RegExpMatchArray | null | undefined = lines.join('\n').match(outputMatcher.lineMatcher);
+	return match ? { regexMatch: match, outputLines: lines } : undefined;
+}

--- a/src/vs/workbench/contrib/terminal/browser/terminal.contribution.membrane.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.contribution.membrane.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ITerminalProfileService } from 'vs/workbench/contrib/terminal/common/terminal';
+import { TerminalService } from 'vs/workbench/contrib/terminal/browser/terminalService.membrane';
+import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { ITerminalEditorService, ITerminalGroupService, ITerminalInstanceService, ITerminalService } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { ITerminalLogService } from 'vs/platform/terminal/common/terminal';
+import { TerminalInstanceService } from 'vs/workbench/contrib/terminal/browser/terminalInstanceService.membrane';
+import { TerminalEditorService } from 'vs/workbench/contrib/terminal/browser/terminalEditorService';
+import { TerminalGroupService } from 'vs/workbench/contrib/terminal/browser/terminalGroupService';
+import { TerminalProfileService } from 'vs/workbench/contrib/terminal/browser/terminalProfileService.membrane';
+import { TerminalLogService } from 'vs/platform/terminal/common/terminalLogService';
+
+// Register services
+registerSingleton(ITerminalLogService, TerminalLogService, InstantiationType.Delayed);
+registerSingleton(ITerminalService, TerminalService, InstantiationType.Delayed);
+registerSingleton(ITerminalEditorService, TerminalEditorService, InstantiationType.Delayed);
+registerSingleton(ITerminalGroupService, TerminalGroupService, InstantiationType.Delayed);
+registerSingleton(ITerminalInstanceService, TerminalInstanceService, InstantiationType.Delayed);
+registerSingleton(ITerminalProfileService, TerminalProfileService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.membrane.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.membrane.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ITerminalInstance, ITerminalInstanceService } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { IShellLaunchConfig, ITerminalBackend, ITerminalBackendRegistry, ITerminalProfile, TerminalExtensions, TerminalLocation } from 'vs/platform/terminal/common/terminal';
+import { URI } from 'vs/base/common/uri';
+import { Emitter, Event } from 'vs/base/common/event';
+import { Registry } from 'vs/platform/registry/common/platform';
+
+export class TerminalInstanceService extends Disposable implements ITerminalInstanceService {
+	declare _serviceBrand: undefined;
+	// private _configHelper: TerminalConfigHelper;
+	private _backendRegistration = new Map<string | undefined, { promise: Promise<void>; resolve: () => void }>();
+
+	private readonly _onDidCreateInstance = this._register(new Emitter<ITerminalInstance>());
+	get onDidCreateInstance(): Event<ITerminalInstance> { return this._onDidCreateInstance.event; }
+
+	constructor(
+		// @IInstantiationService private readonly _instantiationService: IInstantiationService,
+		// @IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		// @IWorkbenchEnvironmentService readonly _environmentService: IWorkbenchEnvironmentService,
+		...args: any[]
+	) {
+		super();
+	}
+
+	createInstance(profile: ITerminalProfile, target: TerminalLocation): ITerminalInstance;
+	createInstance(shellLaunchConfig: IShellLaunchConfig, target: TerminalLocation): ITerminalInstance;
+	createInstance(config: IShellLaunchConfig | ITerminalProfile, target: TerminalLocation): ITerminalInstance {
+		throw new Error('Unimplemented');
+	}
+
+	convertProfileToShellLaunchConfig(shellLaunchConfigOrProfile?: IShellLaunchConfig | ITerminalProfile, cwd?: string | URI): IShellLaunchConfig {
+		// Return empty shell launch config
+		return {};
+	}
+
+	async getBackend(remoteAuthority?: string): Promise<ITerminalBackend | undefined> {
+		return undefined;
+	}
+
+	getRegisteredBackends(): IterableIterator<ITerminalBackend> {
+		return Registry.as<ITerminalBackendRegistry>(TerminalExtensions.Backend).backends.values();
+	}
+
+	didRegisterBackend(remoteAuthority?: string) {
+		this._backendRegistration.get(remoteAuthority)?.resolve();
+	}
+}
+
+registerSingleton(ITerminalInstanceService, TerminalInstanceService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileService.membrane.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileService.membrane.ts
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { throttle } from 'vs/base/common/decorators';
+import { Event } from 'vs/base/common/event';
+import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { OperatingSystem } from 'vs/base/common/platform';
+import { ITerminalProfile, IExtensionTerminalProfile, IShellLaunchConfig } from 'vs/platform/terminal/common/terminal';
+import { IRegisterContributedProfileArgs, ITerminalProfileProvider, ITerminalProfileService } from 'vs/workbench/contrib/terminal/common/terminal';
+
+/*
+ * Links TerminalService with TerminalProfileResolverService
+ * and keeps the available terminal profiles updated
+ */
+export class TerminalProfileService extends Disposable implements ITerminalProfileService {
+	declare _serviceBrand: undefined;
+
+	get onDidChangeAvailableProfiles(): Event<ITerminalProfile[]> { throw new Error('Unsupported'); }
+
+	get profilesReady(): Promise<void> {
+
+		throw new Error('Unsupported');
+	}
+	get availableProfiles(): ITerminalProfile[] {
+
+		throw new Error('Unsupported');
+	}
+	get contributedProfiles(): IExtensionTerminalProfile[] {
+
+		throw new Error('Unsupported');
+	}
+
+	constructor(
+		// @IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		// @IConfigurationService private readonly _configurationService: IConfigurationService,
+		// @ITerminalContributionService private readonly _terminalContributionService: ITerminalContributionService,
+		// @IExtensionService private readonly _extensionService: IExtensionService,
+		// @IRemoteAgentService private _remoteAgentService: IRemoteAgentService,
+		// @IWorkbenchEnvironmentService private readonly _environmentService: IWorkbenchEnvironmentService,
+		// @ITerminalInstanceService private readonly _terminalInstanceService: ITerminalInstanceService
+		...args: any[]
+	) {
+		super();
+	}
+
+	getDefaultProfileName(): string | undefined {
+
+		throw new Error('Unsupported');
+	}
+
+	getDefaultProfile(os?: OperatingSystem): ITerminalProfile | undefined {
+
+		throw new Error('Unsupported');
+	}
+
+
+	@throttle(2000)
+	refreshAvailableProfiles(): void {
+
+		throw new Error('Unsupported');
+	}
+
+	protected async _refreshAvailableProfilesNow(): Promise<void> {
+
+		throw new Error('Unsupported');
+	}
+
+	getContributedProfileProvider(extensionIdentifier: string, id: string): ITerminalProfileProvider | undefined {
+
+		throw new Error('Unsupported');
+	}
+
+	async getPlatformKey(): Promise<string> {
+
+		throw new Error('Unsupported');
+	}
+
+	registerTerminalProfileProvider(extensionIdentifier: string, id: string, profileProvider: ITerminalProfileProvider): IDisposable {
+
+		throw new Error('Unsupported');
+	}
+
+	async registerContributedProfile(args: IRegisterContributedProfileArgs): Promise<void> {
+
+		throw new Error('Unsupported');
+	}
+
+	async getContributedDefaultProfile(shellLaunchConfig: IShellLaunchConfig): Promise<IExtensionTerminalProfile | undefined> {
+
+		throw new Error('Unsupported');
+	}
+
+}

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.membrane.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.membrane.ts
@@ -1,0 +1,237 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { memoize } from 'vs/base/common/decorators';
+import { Event, IDynamicListEventMultiplexer } from 'vs/base/common/event';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { URI } from 'vs/base/common/uri';
+import { ICreateContributedTerminalProfileOptions, ITerminalBackend, ITerminalLaunchError, TerminalLocation, TerminalLocationString } from 'vs/platform/terminal/common/terminal';
+import { IEditableData } from 'vs/workbench/common/views';
+import { ICreateTerminalOptions, IDetachedTerminalInstance, IDetachedXTermOptions, ITerminalConfigHelper, ITerminalGroup, ITerminalInstance, ITerminalInstanceHost, ITerminalLocationOptions, ITerminalService, ITerminalServiceNativeDelegate, TerminalConnectionState } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { IRemoteTerminalAttachTarget, IStartExtensionTerminalRequest, ITerminalProcessExtHostProxy } from 'vs/workbench/contrib/terminal/common/terminal';
+import { ACTIVE_GROUP_TYPE, AUX_WINDOW_GROUP_TYPE, SIDE_GROUP_TYPE } from 'vs/workbench/services/editor/common/editorService';
+import { ITerminalCapabilityImplMap, TerminalCapability } from 'vs/platform/terminal/common/capabilities/capabilities';
+import { GroupIdentifier } from 'vs/workbench/common/editor';
+
+export class TerminalService extends Disposable implements ITerminalService {
+	readonly _serviceBrand: undefined;
+
+	get isProcessSupportRegistered(): boolean { throw new Error('Unsupported'); }
+
+	get connectionState(): TerminalConnectionState { throw new Error('Unsupported'); }
+
+	// Never resolve
+	get whenConnected(): Promise<void> { return new Promise(() => { }); }
+
+	get restoredGroupCount(): number { throw new Error('Unsupported'); }
+
+	get configHelper(): ITerminalConfigHelper { throw new Error('Unsupported'); }
+	get instances(): ITerminalInstance[] {
+
+		throw new Error('Unsupported');
+	}
+	get detachedInstances(): Iterable<IDetachedTerminalInstance> {
+		throw new Error('Unsupported');
+	}
+
+
+	getReconnectedTerminals(_reconnectionOwner: string): ITerminalInstance[] | undefined {
+		return undefined;
+	}
+
+	get defaultLocation(): TerminalLocation { return this.configHelper.config.defaultLocation === TerminalLocationString.Editor ? TerminalLocation.Editor : TerminalLocation.Panel; }
+
+	get activeInstance(): ITerminalInstance | undefined {
+		return undefined;
+	}
+
+	get onDidCreateInstance(): Event<ITerminalInstance> { throw new Error('Unsupported'); }
+	get onDidChangeInstanceDimensions(): Event<ITerminalInstance> { throw new Error('Unsupported'); }
+	get onDidRegisterProcessSupport(): Event<void> { throw new Error('Unsupported'); }
+	get onDidChangeConnectionState(): Event<void> { throw new Error('Unsupported'); }
+	get onDidRequestStartExtensionTerminal(): Event<IStartExtensionTerminalRequest> { throw new Error('Unsupported'); }
+
+	// ITerminalInstanceHost events
+	get onDidDisposeInstance(): Event<ITerminalInstance> { throw new Error('Unsupported'); }
+	get onDidFocusInstance(): Event<ITerminalInstance> { throw new Error('Unsupported'); }
+	get onDidChangeActiveInstance(): Event<ITerminalInstance | undefined> { throw new Error('Unsupported'); }
+	get onDidChangeInstances(): Event<void> { throw new Error('Unsupported'); }
+	get onDidChangeInstanceCapability(): Event<ITerminalInstance> { throw new Error('Unsupported'); }
+
+	// Terminal view events
+	get onDidChangeActiveGroup(): Event<ITerminalGroup | undefined> { throw new Error('Unsupported'); }
+
+	// Lazily initialized events that fire when the specified event fires on _any_ terminal
+	@memoize get onAnyInstanceDataInput() { return this.createOnInstanceEvent(e => e.onDidInputData); }
+	@memoize get onAnyInstanceIconChange() { return this.createOnInstanceEvent(e => e.onIconChanged); }
+	@memoize get onAnyInstanceMaximumDimensionsChange() { return this.createOnInstanceEvent(e => Event.map(e.onMaximumDimensionsChanged, () => e, e.store)); }
+	@memoize get onAnyInstancePrimaryStatusChange() { return this.createOnInstanceEvent(e => Event.map(e.statusList.onDidChangePrimaryStatus, () => e, e.store)); }
+	@memoize get onAnyInstanceProcessIdReady() { return this.createOnInstanceEvent(e => e.onProcessIdReady); }
+	@memoize get onAnyInstanceSelectionChange() { return this.createOnInstanceEvent(e => e.onDidChangeSelection); }
+	@memoize get onAnyInstanceTitleChange() { return this.createOnInstanceEvent(e => e.onTitleChanged); }
+
+	constructor(
+		// @IContextKeyService private _contextKeyService: IContextKeyService,
+		// @ILifecycleService private readonly _lifecycleService: ILifecycleService,
+		// @ITerminalLogService private readonly _logService: ITerminalLogService,
+		// @IDialogService private _dialogService: IDialogService,
+		// @IInstantiationService private _instantiationService: IInstantiationService,
+		// @IRemoteAgentService private _remoteAgentService: IRemoteAgentService,
+		// @IViewsService private _viewsService: IViewsService,
+		// @IConfigurationService private readonly _configurationService: IConfigurationService,
+		// @IWorkbenchEnvironmentService private readonly _environmentService: IWorkbenchEnvironmentService,
+		// @ITerminalEditorService private readonly _terminalEditorService: ITerminalEditorService,
+		// @ITerminalGroupService private readonly _terminalGroupService: ITerminalGroupService,
+		// @ITerminalInstanceService private readonly _terminalInstanceService: ITerminalInstanceService,
+		// @IEditorGroupsService private readonly _editorGroupsService: IEditorGroupsService,
+		// @ITerminalProfileService private readonly _terminalProfileService: ITerminalProfileService,
+		// @IExtensionService private readonly _extensionService: IExtensionService,
+		// @INotificationService private readonly _notificationService: INotificationService,
+		// @IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		// @ICommandService private readonly _commandService: ICommandService,
+		// @IKeybindingService private readonly _keybindingService: IKeybindingService,
+		// @ITimerService private readonly _timerService: ITimerService
+		...args: any[]
+	) {
+		super();
+
+	}
+
+	async showProfileQuickPick(type: 'setDefault' | 'createInstance', cwd?: string | URI): Promise<ITerminalInstance | undefined> {
+		throw new Error('Unsupported');
+	}
+
+	async initializePrimaryBackend() {
+		throw new Error('Unsupported');
+	}
+
+	getPrimaryBackend(): ITerminalBackend | undefined {
+		throw new Error('Unsupported');
+	}
+
+	setActiveInstance(value: ITerminalInstance) {
+		throw new Error('Unsupported');
+	}
+
+	async focusActiveInstance(): Promise<void> {
+		throw new Error('Unsupported');
+	}
+
+	async createContributedTerminalProfile(extensionIdentifier: string, id: string, options: ICreateContributedTerminalProfileOptions): Promise<void> {
+		throw new Error('Unsupported');
+	}
+
+	async safeDisposeTerminal(instance: ITerminalInstance): Promise<void> {
+		throw new Error('Unsupported');
+	}
+
+	async getActiveOrCreateInstance(options?: { acceptsInput?: boolean }): Promise<ITerminalInstance> {
+		throw new Error('Unsupported');
+	}
+
+	async revealActiveTerminal(preserveFocus?: boolean): Promise<void> {
+		throw new Error('Unsupported');
+	}
+
+	setEditable(instance: ITerminalInstance, data?: IEditableData | null): void {
+		throw new Error('Unsupported');
+	}
+
+	isEditable(instance: ITerminalInstance | undefined): boolean {
+		throw new Error('Unsupported');
+	}
+
+	getEditableData(instance: ITerminalInstance): IEditableData | undefined {
+		throw new Error('Unsupported');
+	}
+
+	requestStartExtensionTerminal(proxy: ITerminalProcessExtHostProxy, cols: number, rows: number): Promise<ITerminalLaunchError | undefined> {
+		throw new Error('Unsupported');
+	}
+
+	setNativeDelegate(nativeDelegate: ITerminalServiceNativeDelegate): void {
+		throw new Error('Unsupported');
+	}
+
+	refreshActiveGroup(): void {
+		throw new Error('Unsupported');
+	}
+
+	getInstanceFromId(terminalId: number): ITerminalInstance | undefined {
+		throw new Error('Unsupported');
+	}
+
+	getInstanceFromIndex(terminalIndex: number): ITerminalInstance {
+		throw new Error('Unsupported');
+	}
+
+	getInstanceFromResource(resource: URI | undefined): ITerminalInstance | undefined {
+		throw new Error('Unsupported');
+	}
+
+	isAttachedToTerminal(remoteTerm: IRemoteTerminalAttachTarget): boolean {
+		throw new Error('Unsupported');
+	}
+
+	moveToEditor(source: ITerminalInstance, group?: GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE | AUX_WINDOW_GROUP_TYPE): void {
+		throw new Error('Unsupported');
+	}
+
+	moveIntoNewEditor(source: ITerminalInstance): void {
+		throw new Error('Unsupported');
+	}
+
+	async moveToTerminalView(source?: ITerminalInstance | URI, target?: ITerminalInstance, side?: 'before' | 'after'): Promise<void> {
+		throw new Error('Unsupported');
+	}
+
+	registerProcessSupport(isSupported: boolean): void {
+		throw new Error('Unsupported');
+	}
+
+	protected async _showTerminalCloseConfirmation(singleTerminal?: boolean): Promise<boolean> {
+		throw new Error('Unsupported');
+	}
+
+	getDefaultInstanceHost(): ITerminalInstanceHost {
+		throw new Error('Unsupported');
+	}
+
+	async getInstanceHost(location: ITerminalLocationOptions | undefined): Promise<ITerminalInstanceHost> {
+		throw new Error('Unsupported');
+	}
+
+	async createTerminal(options?: ICreateTerminalOptions): Promise<ITerminalInstance> {
+		throw new Error('Unsupported');
+	}
+
+	async createDetachedTerminal(options: IDetachedXTermOptions): Promise<IDetachedTerminalInstance> {
+		throw new Error('Unsupported');
+	}
+
+	async resolveLocation(location?: ITerminalLocationOptions): Promise<TerminalLocation | undefined> {
+		throw new Error('Unsupported');
+	}
+
+	async setContainers(panelContainer: HTMLElement, terminalContainer: HTMLElement): Promise<void> {
+		throw new Error('Unsupported');
+	}
+
+	getEditingTerminal(): ITerminalInstance | undefined {
+		return undefined;
+	}
+
+	setEditingTerminal(instance: ITerminalInstance | undefined) {
+		return undefined;
+	}
+
+	createOnInstanceEvent<T>(getEvent: (instance: ITerminalInstance) => Event<T>): Event<T> {
+		throw new Error('Unsupported');
+	}
+
+	createOnInstanceCapabilityEvent<T extends TerminalCapability, K>(capabilityId: T, getEvent: (capability: ITerminalCapabilityImplMap[T]) => Event<K>): IDynamicListEventMultiplexer<{ instance: ITerminalInstance; data: K }> {
+		throw new Error('Unsupported');
+	}
+}


### PR DESCRIPTION
## Problem

We don't want to show the `Terminal` tab since we don't support terminals in the Web IDE.

## Background
VSCode is very modular so most of the functionality comes in the form of "contributions", not only for extensions but also built-in features.

Many features in VSCode depend on terminal functionality (e.g. tasks) so it's not as easy as just deleting the contributions. I tried that and dependents start failing at runtime because there's no `ITerminalService`.

Thankfully VScode uses dependency injection everywhere, this allows us to replace components with dummy ones that don't do anything. so I replaced `TerminalService` with our own empty shell of a service. The empty shell is just there to satisfy the dependency injection system. Also did the same for a few other related services. 

## What's in this PR?

I removed most of the terminal-related contributions (terminal.contribution.ts). Including: commands, the terminal tab, menu items, keybindings, and so on.

Note that there's still quite a bit of terminal-related code left that I think will end up in our build (we'll see after this build). We might be able to use a webpack plugin to for example, replace xterm.js with a dummy module and shave off a couple of MB.

## How will this affect merging VSCode from upstream?

To avoid conflicts when upgrading VSCode in the future:

 - Deleted `terminalService.ts` to ensure it's not referenced anywhere.
 - Created `terminalService.membrane.ts` with the empty shell service implementation.
 - (same for related services)
  
That way any conflicts will appear as "they modified this file that we deleted and don't care about".

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
