### PR TITLE
Don't cache workspace configuration (folders)

### DIFF
--- a/src/vs/workbench/services/configuration/browser/configuration.ts
+++ b/src/vs/workbench/services/configuration/browser/configuration.ts
@@ -720,10 +720,13 @@ export class WorkspaceConfiguration extends Disposable {
 		if (reload) {
 			await this.reload();
 		}
-		this.updateCache();
+		// MEMBRANE: don't cache the workspace configuration (i.e. folders). We want this to be generated on launch by the
+		// extension from the files in the user's account.
+		// this.updateCache();
 		this._onDidUpdateConfiguration.fire(fromCache);
 	}
 
+	// @ts-ignore 6133
 	private async updateCache(): Promise<void> {
 		if (this._workspaceIdentifier && this.configurationCache.needsCaching(this._workspaceIdentifier.configPath) && this._workspaceConfiguration instanceof FileServiceBasedWorkspaceConfiguration) {
 			const content = await this._workspaceConfiguration.resolveContent(this._workspaceIdentifier);


### PR DESCRIPTION
Caching the workspace file causes problems so this PR disables the cache.

 - If the cached workspace can't load for whatever reason, not workspace is loaded at all
 - It's possible for the cached folder to have incorrect folders

Instead we just recreate the file every time (vscode waits for the provider of `memfs` to register itself and then proceeds to read the workspace file).


Note: it disables _saving_ of the cache, you need to logout to clear any caches.