### PR TITLE
Search only within the workspace/root folder.

### DIFF
--- a/src/vs/workbench/services/search/common/textSearchManager.ts
+++ b/src/vs/workbench/services/search/common/textSearchManager.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { flatten, mapArrayOrNot } from 'vs/base/common/arrays';
+import { mapArrayOrNot } from 'vs/base/common/arrays';
 import { isThenable } from 'vs/base/common/async';
 import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
 import { toErrorMessage } from 'vs/base/common/errorMessage';
@@ -29,60 +29,73 @@ export class TextSearchManager {
 	constructor(private query: ITextQuery, private provider: TextSearchProvider, private fileUtils: IFileUtils, private processType: ITextSearchStats['type']) { }
 
 	search(onProgress: (matches: IFileMatch[]) => void, token: CancellationToken): Promise<ISearchCompleteStats> {
-		const folderQueries = this.query.folderQueries || [];
 		const tokenSource = new CancellationTokenSource(token);
 
 		return new Promise<ISearchCompleteStats>((resolve, reject) => {
 			this.collector = new TextSearchResultsCollector(onProgress);
 
 			let isCanceled = false;
-			const onResult = (result: TextSearchResult, folderIdx: number) => {
+			const onResult = (result: TextSearchResult) => {
 				if (isCanceled) {
 					return;
 				}
 
 				if (!this.isLimitHit) {
 					const resultSize = this.resultSize(result);
-					if (extensionResultIsMatch(result) && typeof this.query.maxResults === 'number' && this.resultCount + resultSize > this.query.maxResults) {
+					if (
+						extensionResultIsMatch(result) &&
+						typeof this.query.maxResults === 'number' &&
+						this.resultCount + resultSize > this.query.maxResults
+					) {
 						this.isLimitHit = true;
 						isCanceled = true;
 						tokenSource.cancel();
 
-						result = this.trimResultToSize(result, this.query.maxResults - this.resultCount);
+						result = this.trimResultToSize(
+							result,
+							this.query.maxResults - this.resultCount,
+						);
 					}
 
 					const newResultSize = this.resultSize(result);
 					this.resultCount += newResultSize;
 					if (newResultSize > 0 || !extensionResultIsMatch(result)) {
-						this.collector!.add(result, folderIdx);
+						this.collector!.add(result, 0); // Using 0 as a default folder index
 					}
 				}
 			};
 
-			// For each root folder
-			Promise.all(folderQueries.map((fq, i) => {
-				return this.searchInFolder(fq, r => onResult(r, i), tokenSource.token);
-			})).then(results => {
-				tokenSource.dispose();
-				this.collector!.flush();
+			// Single search call
+			const folderQuery = this.query.folderQueries?.[0] || {
+				folder: URI.file('/'),
+			};
+			this.searchInFolder(
+				folderQuery,
+				(r) => onResult(r),
+				tokenSource.token,
+			).then(
+				(result) => {
+					tokenSource.dispose();
+					this.collector!.flush();
 
-				const someFolderHitLImit = results.some(result => !!result && !!result.limitHit);
-				resolve({
-					limitHit: this.isLimitHit || someFolderHitLImit,
-					messages: flatten(results.map(result => {
-						if (!result?.message) { return []; }
-						if (Array.isArray(result.message)) { return result.message; }
-						else { return [result.message]; }
-					})),
-					stats: {
-						type: this.processType
-					}
-				});
-			}, (err: Error) => {
-				tokenSource.dispose();
-				const errMsg = toErrorMessage(err);
-				reject(new Error(errMsg));
-			});
+					resolve({
+						limitHit: this.isLimitHit || !!result?.limitHit,
+						messages: result?.message
+							? Array.isArray(result.message)
+								? result.message
+								: [result.message]
+							: [],
+						stats: {
+							type: this.processType,
+						},
+					});
+				},
+				(err: Error) => {
+					tokenSource.dispose();
+					const errMsg = toErrorMessage(err);
+					reject(new Error(errMsg));
+				},
+			);
 		});
 	}
 

--- a/src/vs/workbench/services/search/common/textSearchManager.ts
+++ b/src/vs/workbench/services/search/common/textSearchManager.ts
@@ -65,7 +65,7 @@ export class TextSearchManager {
 				}
 			};
 
-			// Single search call
+			// MEMBRANE: Single search call
 			const folderQuery = this.query.folderQueries?.[0] || {
 				folder: URI.file('/'),
 			};

--- a/src/vs/workbench/services/search/common/textSearchManager.ts
+++ b/src/vs/workbench/services/search/common/textSearchManager.ts
@@ -60,7 +60,7 @@ export class TextSearchManager {
 					const newResultSize = this.resultSize(result);
 					this.resultCount += newResultSize;
 					if (newResultSize > 0 || !extensionResultIsMatch(result)) {
-						this.collector!.add(result, 0); // Using 0 as a default folder index
+						this.collector!.add(result, 0); // MEMBRANE: Using 0 as a default folder index
 					}
 				}
 			};

--- a/src/vs/workbench/services/search/common/textSearchManager.ts
+++ b/src/vs/workbench/services/search/common/textSearchManager.ts
@@ -42,11 +42,7 @@ export class TextSearchManager {
 
 				if (!this.isLimitHit) {
 					const resultSize = this.resultSize(result);
-					if (
-						extensionResultIsMatch(result) &&
-						typeof this.query.maxResults === 'number' &&
-						this.resultCount + resultSize > this.query.maxResults
-					) {
+					if (extensionResultIsMatch(result) && typeof this.query.maxResults === 'number' && this.resultCount + resultSize > this.query.maxResults) {
 						this.isLimitHit = true;
 						isCanceled = true;
 						tokenSource.cancel();


### PR DESCRIPTION
These changes simplify the search by using a single query.

- The original code performed searches across multiple folders (folderQueries). this PR simplifies this to search only in the root of the workspace

- By searching in only one folder instead of multiple, the search process will be faster and more efficient, especially when we have many membrane programs. 

https://github.com/membrane-io/mnode/pull/168