### PR TITLE
T-980: Ignore false alarm file watcher error

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
+++ b/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
@@ -230,7 +230,9 @@ export class MainThreadFileSystemEventService implements MainThreadFileSystemEve
 					opts.recursive = false;
 				}
 			} catch (error) {
-				this._logService.error(`MainThreadFileSystemEventService#$watch(): failed to stat a resource for file watching (extension: ${extensionId}, path: ${uri.toString(true)}, recursive: ${opts.recursive}, session: ${session}): ${error}`);
+				// MEMBRANE: change from latest vscode upstream
+				// https://github.com/microsoft/vscode/pull/207679/files
+				// ignore
 			}
 		}
 


### PR DESCRIPTION
https://github.com/microsoft/vscode/pull/207679/files

The latest upstream `microsoft/vscode` ignores this false alarm. Commenting it out in our fork for now, until we pull in the upstream.

==========
Close T-980