### PR TITLE
T-946: Do not suppress TS semantic diagnostics

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -1322,7 +1322,7 @@
         },
         "typescript.tsserver.web.projectWideIntellisense.suppressSemanticErrors": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "%configuration.tsserver.web.projectWideIntellisense.suppressSemanticErrors%",
           "scope": "window"
         },

--- a/extensions/typescript-language-features/src/configuration/configuration.ts
+++ b/extensions/typescript-language-features/src/configuration/configuration.ts
@@ -255,7 +255,7 @@ export abstract class BaseServiceConfigurationProvider implements ServiceConfigu
 	}
 
 	private readWebProjectWideIntellisenseSuppressSemanticErrors(configuration: vscode.WorkspaceConfiguration): boolean {
-		return configuration.get<boolean>('typescript.tsserver.web.projectWideIntellisense.suppressSemanticErrors', true);
+		return configuration.get<boolean>('typescript.tsserver.web.projectWideIntellisense.suppressSemanticErrors', false);
 	}
 
 	private readWorkspaceSymbolsExcludeLibrarySymbols(configuration: vscode.WorkspaceConfiguration): boolean {


### PR DESCRIPTION
## Description

Defaults the TS server setting to suppress semantic errors for external packages to `false`. Here's an example:

<img width="911" alt="ts-semantic-diagnostics" src="https://github.com/user-attachments/assets/02d10131-13e9-48e8-b4a6-dc26bd542641">

## Testing

Open the preview deployment on https://github.com/membrane-io/mnode/pull/217 and write some code with invalid types.

## Upstream

I am a bit confused by the status of this setting in vscode upstream. On the main branch [it is still `true`](https://github.com/microsoft/vscode/blame/main/extensions/typescript-language-features/package.json#L1447), but the latest git blame points to [this PR that flips it to `false`](https://github.com/microsoft/vscode/pull/212370).