### PR TITLE
T-1173: Fix markdown preview links

### DIFF
--- a/extensions/markdown-language-features/preview-src/index.ts
+++ b/extensions/markdown-language-features/preview-src/index.ts
@@ -332,11 +332,12 @@ document.addEventListener('click', event => {
 
 			let hrefText = node.getAttribute('data-href');
 			if (!hrefText) {
+				// MEMBRANE: already fixed upstream in https://github.com/microsoft/vscode/pull/228633
+				hrefText = node.getAttribute('href');
 				// Pass through known schemes
-				if (passThroughLinkSchemes.some(scheme => node.href.startsWith(scheme))) {
+				if (passThroughLinkSchemes.some(scheme => hrefText.startsWith(scheme))) {
 					return;
 				}
-				hrefText = node.getAttribute('href');
 			}
 
 			// If original link doesn't look like a url, delegate back to VS Code to resolve

--- a/extensions/markdown-language-features/src/preview/security.ts
+++ b/extensions/markdown-language-features/src/preview/security.ts
@@ -60,7 +60,8 @@ export class ExtensionContentSecurityPolicyArbiter implements ContentSecurityPol
 	}
 
 	public shouldDisableSecurityWarnings(): boolean {
-		return this._workspaceState.get<boolean>(this._should_disable_security_warning_key, false);
+		// MEMBRANE: disable markdown security warning
+		return this._workspaceState.get<boolean>(this._should_disable_security_warning_key, true);
 	}
 
 	public setShouldDisableSecurityWarning(disabled: boolean): Thenable<void> {

--- a/extensions/markdown-language-features/src/preview/security.ts
+++ b/extensions/markdown-language-features/src/preview/security.ts
@@ -60,8 +60,7 @@ export class ExtensionContentSecurityPolicyArbiter implements ContentSecurityPol
 	}
 
 	public shouldDisableSecurityWarnings(): boolean {
-		// MEMBRANE: disable markdown security warning
-		return this._workspaceState.get<boolean>(this._should_disable_security_warning_key, true);
+		return this._workspaceState.get<boolean>(this._should_disable_security_warning_key, false);
 	}
 
 	public setShouldDisableSecurityWarning(disabled: boolean): Thenable<void> {

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -552,6 +552,8 @@
 							event.view.scrollTo(0, 0);
 						}
 					} else {
+						// MEMBRANE: note - an outdated version of this file is being served from the CDN
+						// MEMBRANE: see T-1173 for more detail
 						hostMessaging.postMessage('did-click-link', { uri: node.href.baseVal || node.href });
 					}
 					event.preventDefault();

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -222,7 +222,9 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 			this.handleNoCspFound();
 		}));
 
-		this._register(this.on('did-click-link', ({ uri }) => {
+		this._register(this.on('did-click-link', (data) => {
+			// MEMBRANE: fix for T-1173
+			const uri = typeof data === 'string' ? data : data.uri;
 			this._onDidClickLink.fire(uri);
 		}));
 

--- a/src/vs/workbench/contrib/webview/browser/webviewMessages.d.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewMessages.d.ts
@@ -19,7 +19,8 @@ type KeyEvent = {
 
 export type FromWebviewMessage = {
 	'onmessage': { message: any; transfer?: ArrayBuffer[] };
-	'did-click-link': { uri: string };
+	// MEMBRANE: fix for T-1173
+	'did-click-link': { uri: string } | string;
 	'did-scroll': { scrollYPercentage: number };
 	'did-focus': void;
 	'did-blur': void;


### PR DESCRIPTION
The `index.html` file for extension WebViews gets fetched from a Microsoft CDN, and we're fetching a stale version that's missing the fix for markdown preview links. Instead of fixing that root CDN issue, which would be a bigger lift, this PR just updates the type of the href that the click handler expects.

See T-1173 description for more context.