### PR TITLE
T-1223: add `membrane.io` as a trusted domain

### DIFF
--- a/src/vs/workbench/browser/window.ts
+++ b/src/vs/workbench/browser/window.ts
@@ -297,6 +297,12 @@ export class BrowserWindow extends BaseWindow {
 					}
 				}
 
+				// MEMBRANE: special case for logout
+				if (href === 'https://membrane.io/?logout=true') {
+					mainWindow.location.href = '/?logout=true';
+					return true;
+				}
+
 				// HTTP(s): open in new window and deal with potential popup blockers
 				if (matchesScheme(href, Schemas.http) || matchesScheme(href, Schemas.https)) {
 					if (isSafari) {

--- a/src/vs/workbench/contrib/url/browser/trustedDomains.ts
+++ b/src/vs/workbench/contrib/url/browser/trustedDomains.ts
@@ -208,6 +208,8 @@ export function readStaticTrustedDomains(accessor: ServicesAccessor): IStaticTru
 	const environmentService = accessor.get(IBrowserWorkbenchEnvironmentService);
 
 	const defaultTrustedDomains = [
+		// MEMBRANE: add membrane.io to the list of trusted domains to skip confirmation dialog
+		'https://membrane.io',
 		...productService.linkProtectionTrustedDomains ?? [],
 		...environmentService.options?.additionalTrustedDomains ?? []
 	];


### PR DESCRIPTION
Related to https://github.com/membrane-io/mnode/pull/294

Also has the nice side effect of skipping the confirmation dialog for all links to membrane.io from the IDE (e.g. /share pages).