### PR TITLE
Disable typescript syntax server since we don't really need it

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -1192,7 +1192,7 @@
           "type": "string",
           "scope": "window",
           "description": "%configuration.tsserver.useSyntaxServer%",
-          "default": "auto",
+          "default": "never",
           "enum": [
             "always",
             "never",


### PR DESCRIPTION
We don't really need to have a separate tsserver instance for syntax highlighting because our programs are small. This should save some memory, speed up startup time, as well as make it less confusing to debug/develop our plugin since there will be only one instance per program.