### PR TITLE
Snappier intellisense

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/bufferSyncSupport.ts
+++ b/extensions/typescript-language-features/src/tsServer/bufferSyncSupport.ts
@@ -684,6 +684,8 @@ export default class BufferSyncSupport extends Disposable {
 	}
 
 	private triggerDiagnostics(delay: number = 200) {
+		/// MEMBRNAE: make intellisense and ts-plugin respond faster by reducing the artificial delay.
+		delay = 50;
 		this.diagnosticDelayer.trigger(() => {
 			this.sendPendingDiagnostics();
 		}, delay);

--- a/src/vs/editor/contrib/codelens/browser/codelensController.ts
+++ b/src/vs/editor/contrib/codelens/browser/codelensController.ts
@@ -51,8 +51,9 @@ export class CodeLensContribution implements IEditorContribution {
 		@INotificationService private readonly _notificationService: INotificationService,
 		@ICodeLensCache private readonly _codeLensCache: ICodeLensCache
 	) {
-		this._provideCodeLensDebounce = debounceService.for(_languageFeaturesService.codeLensProvider, 'CodeLensProvide', { min: 250 });
-		this._resolveCodeLensesDebounce = debounceService.for(_languageFeaturesService.codeLensProvider, 'CodeLensResolve', { min: 250, salt: 'resolve' });
+		/// MEMBRANE: reduce the debounce time to make our CodeLens appear faster
+		this._provideCodeLensDebounce = debounceService.for(_languageFeaturesService.codeLensProvider, 'CodeLensProvide', { min: 10 });
+		this._resolveCodeLensesDebounce = debounceService.for(_languageFeaturesService.codeLensProvider, 'CodeLensResolve', { min: 10, salt: 'resolve' });
 		this._resolveCodeLensesScheduler = new RunOnceScheduler(() => this._resolveCodeLensesInViewport(), this._resolveCodeLensesDebounce.default());
 
 		this._disposables.add(this._editor.onDidChangeModel(() => this._onModelChange()));


### PR DESCRIPTION
While fixing a recent issue with ts-plugin I noticed that intellisense is actually slowed down to account for huge files and perhaps reduce flickering. I lowered a couple of delays and indeed feels much responsive, I think this should be okay because our files/projects tend to be small.