### PR TITLE
T-1153  Fix typings errors.

### DIFF
--- a/extensions/typescript-language-features/web/src/typingsInstaller/typingsInstaller.ts
+++ b/extensions/typescript-language-features/web/src/typingsInstaller/typingsInstaller.ts
@@ -70,6 +70,8 @@ export class WebTypingsInstallerClient implements ts.server.ITypingsInstaller {
 				break;
 			case 'event::beginInstallTypes':
 			case 'event::endInstallTypes':
+			// TODO(@zkat): maybe do something with this?
+			case 'action::watchTypingLocations':
 				// Don't care.
 				break;
 			default:


### PR DESCRIPTION
To ignore this.
 
Uncaught (in promise) Error: unexpected response: [object Object]
    at e.WebTypingsInstallerClient.handleResponse (tsserver.web.js:31:20991)
    at Q.handleResponse (tsserver.web.js:31:20715)
    at Q.sendResponse (tsserver.web.js:31:22537)
    at Q.watchFiles (tsserver.web.js:7:2108512)
    at Q.install (tsserver.web.js:7:2103298)
    at tsserver.web.js:31:21551
