### PR TITLE
T-1284: rm `EXPLORER` flash on load

### DIFF
--- a/src/vs/workbench/api/browser/viewsExtensionPoint.ts
+++ b/src/vs/workbench/api/browser/viewsExtensionPoint.ts
@@ -417,13 +417,19 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
 		containers.forEach(descriptor => {
 			const themeIcon = ThemeIcon.fromString(descriptor.icon);
 
+			// MEMBRANE: make Membrane Navigator the default view container on the left sidebar
+			const options: { isDefault?: boolean; doNotRegisterOpenCommand?: boolean } = {};
+			if (descriptor.id === 'membraneContainer') {
+				options.isDefault = true;
+			}
+
 			// MEMBRANE: move Program Overview to auxiliary bar (right-side bar)
 			const overridenLocation = descriptor.id === 'membraneAuxContainer' ? ViewContainerLocation.AuxiliaryBar : location;
 
 			const icon = themeIcon || resources.joinPath(extension.extensionLocation, descriptor.icon);
 			const id = `workbench.view.extension.${descriptor.id}`;
 			const title = descriptor.title || id;
-			const viewContainer = this.registerCustomViewContainer(id, title, icon, order++, extension.identifier, overridenLocation);
+			const viewContainer = this.registerCustomViewContainer(id, title, icon, order++, extension.identifier, overridenLocation, options);
 
 			// Move those views that belongs to this container
 			if (existingViewContainers.length) {
@@ -441,7 +447,7 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
 		return order;
 	}
 
-	private registerCustomViewContainer(id: string, title: string, icon: URI | ThemeIcon, order: number, extensionId: ExtensionIdentifier | undefined, location: ViewContainerLocation): ViewContainer {
+	private registerCustomViewContainer(id: string, title: string, icon: URI | ThemeIcon, order: number, extensionId: ExtensionIdentifier | undefined, location: ViewContainerLocation, options: { isDefault?: boolean; doNotRegisterOpenCommand?: boolean }): ViewContainer {
 		let viewContainer = this.viewContainersRegistry.get(id);
 
 		if (!viewContainer) {
@@ -457,7 +463,7 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
 				hideIfEmpty: true,
 				order,
 				icon,
-			}, location);
+			}, location, options);
 
 		}
 

--- a/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
@@ -51,13 +51,14 @@ export class ExplorerViewletViewsContribution extends Disposable implements IWor
 		super();
 
 		progressService.withProgress({ location: ProgressLocation.Explorer }, () => workspaceContextService.getCompleteWorkspace()).finally(() => {
-			this.registerViews();
+			// this.registerViews();
 
-			this._register(workspaceContextService.onDidChangeWorkbenchState(() => this.registerViews()));
-			this._register(workspaceContextService.onDidChangeWorkspaceFolders(() => this.registerViews()));
+			// this._register(workspaceContextService.onDidChangeWorkbenchState(() => this.registerViews()));
+			// this._register(workspaceContextService.onDidChangeWorkspaceFolders(() => this.registerViews()));
 		});
 	}
 
+	// @ts-expect-error 'registerViews' is declared but its value is never read
 	private registerViews(): void {
 		mark('code/willRegisterExplorerViews');
 
@@ -268,7 +269,7 @@ export const VIEW_CONTAINER: ViewContainer = viewContainerRegistry.registerViewC
 		order: 0
 	},
 	// MEMBRANE: the Membrane Navigator is the default view container on the left sidebar
-}, ViewContainerLocation.Sidebar, { isDefault: false });
+}, ViewContainerLocation.Sidebar, { isDefault: false, doNotRegisterOpenCommand: true });
 
 const openFolder = localize('openFolder', "Open Folder");
 const addAFolder = localize('addAFolder', "add a folder");

--- a/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
@@ -267,7 +267,8 @@ export const VIEW_CONTAINER: ViewContainer = viewContainerRegistry.registerViewC
 		keybindings: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyE },
 		order: 0
 	},
-}, ViewContainerLocation.Sidebar, { isDefault: true });
+	// MEMBRANE: the Membrane Navigator is the default view container on the left sidebar
+}, ViewContainerLocation.Sidebar, { isDefault: false });
 
 const openFolder = localize('openFolder', "Open Folder");
 const addAFolder = localize('addAFolder', "add a folder");

--- a/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from 'vs/nls';
-import { ToggleAutoSaveAction, FocusFilesExplorer, GlobalCompareResourcesAction, ShowActiveFileInExplorer, CompareWithClipboardAction, NEW_FILE_COMMAND_ID, NEW_FILE_LABEL, NEW_FOLDER_COMMAND_ID, NEW_FOLDER_LABEL, TRIGGER_RENAME_LABEL, MOVE_FILE_TO_TRASH_LABEL, COPY_FILE_LABEL, PASTE_FILE_LABEL, FileCopiedContext, renameHandler, moveFileToTrashHandler, copyFileHandler, pasteFileHandler, deleteFileHandler, cutFileHandler, DOWNLOAD_COMMAND_ID, openFilePreserveFocusHandler, DOWNLOAD_LABEL, OpenActiveFileInEmptyWorkspace, UPLOAD_COMMAND_ID, UPLOAD_LABEL, CompareNewUntitledTextFilesAction, SetActiveEditorReadonlyInSession, SetActiveEditorWriteableInSession, ToggleActiveEditorReadonlyInSession, ResetActiveEditorReadonlyInSession } from 'vs/workbench/contrib/files/browser/fileActions';
+// MEMBRANE: rm FocusFilesExplorer, NEW_FOLDER_COMMAND_ID, NEW_FOLDER_LABEL imports
+import { ToggleAutoSaveAction, GlobalCompareResourcesAction, ShowActiveFileInExplorer, CompareWithClipboardAction, NEW_FILE_COMMAND_ID, NEW_FILE_LABEL, TRIGGER_RENAME_LABEL, MOVE_FILE_TO_TRASH_LABEL, COPY_FILE_LABEL, PASTE_FILE_LABEL, FileCopiedContext, renameHandler, moveFileToTrashHandler, copyFileHandler, pasteFileHandler, deleteFileHandler, cutFileHandler, DOWNLOAD_COMMAND_ID, openFilePreserveFocusHandler, DOWNLOAD_LABEL, OpenActiveFileInEmptyWorkspace, UPLOAD_COMMAND_ID, UPLOAD_LABEL, CompareNewUntitledTextFilesAction, SetActiveEditorReadonlyInSession, SetActiveEditorWriteableInSession, ToggleActiveEditorReadonlyInSession, ResetActiveEditorReadonlyInSession } from 'vs/workbench/contrib/files/browser/fileActions';
 import { revertLocalChangesCommand, acceptLocalChangesCommand, CONFLICT_RESOLUTION_CONTEXT } from 'vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler';
 import { MenuId, MenuRegistry, registerAction2 } from 'vs/platform/actions/common/actions';
 import { ICommandAction } from 'vs/platform/action/common/action';
@@ -15,7 +16,7 @@ import { CommandsRegistry, ICommandHandler } from 'vs/platform/commands/common/c
 import { ContextKeyExpr, ContextKeyExpression } from 'vs/platform/contextkey/common/contextkey';
 import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { FilesExplorerFocusCondition, ExplorerRootContext, ExplorerFolderContext, ExplorerResourceNotReadonlyContext, ExplorerResourceCut, ExplorerResourceMoveableToTrash, ExplorerResourceAvailableEditorIdsContext, FoldersViewVisibleContext } from 'vs/workbench/contrib/files/common/files';
-// Membrane
+// MEMBRANE
 // import { ADD_ROOT_FOLDER_COMMAND_ID, ADD_ROOT_FOLDER_LABEL } from 'vs/workbench/browser/actions/workspaceCommands';
 import { CLOSE_SAVED_EDITORS_COMMAND_ID, CLOSE_EDITORS_IN_GROUP_COMMAND_ID, CLOSE_EDITOR_COMMAND_ID, CLOSE_OTHER_EDITORS_IN_GROUP_COMMAND_ID, REOPEN_WITH_COMMAND_ID } from 'vs/workbench/browser/parts/editor/editorCommands';
 import { AutoSaveAfterShortDelayContext } from 'vs/workbench/services/filesConfiguration/common/filesConfigurationService';
@@ -32,8 +33,9 @@ import { Categories } from 'vs/platform/action/common/actionCommonCategories';
 // Contribute Global Actions
 
 registerAction2(GlobalCompareResourcesAction);
-registerAction2(FocusFilesExplorer);
-registerAction2(ShowActiveFileInExplorer);
+// MEMBRANE: do not expose command to open the explorer viewlet
+// registerAction2(FocusFilesExplorer);
+registerAction2(ShowActiveFileInExplorer); // MEMBRANE: keep this because we open the Navigator instead
 registerAction2(CompareWithClipboardAction);
 registerAction2(CompareNewUntitledTextFilesAction);
 registerAction2(ToggleAutoSaveAction);
@@ -262,12 +264,13 @@ appendToCommandPalette({
 	category: Categories.File
 }, WorkspaceFolderCountContext.notEqualsTo('0'));
 
-appendToCommandPalette({
-	id: NEW_FOLDER_COMMAND_ID,
-	title: { value: NEW_FOLDER_LABEL, original: 'New Folder' },
-	category: Categories.File,
-	metadata: { description: nls.localize2('newFolderDescription', "Create a new folder or directory") }
-}, WorkspaceFolderCountContext.notEqualsTo('0'));
+// MEMBRANE: we don't register new folder action
+// appendToCommandPalette({
+// 	id: NEW_FOLDER_COMMAND_ID,
+// 	title: { value: NEW_FOLDER_LABEL, original: 'New Folder' },
+// 	category: Categories.File,
+// 	metadata: { description: nls.localize2('newFolderDescription', "Create a new folder or directory") }
+// }, WorkspaceFolderCountContext.notEqualsTo('0'));
 
 appendToCommandPalette({
 	id: NEW_UNTITLED_FILE_COMMAND_ID,
@@ -464,16 +467,16 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
 	when: ExplorerFolderContext
 });
 
-MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
-	group: 'navigation',
-	order: 6,
-	command: {
-		id: NEW_FOLDER_COMMAND_ID,
-		title: NEW_FOLDER_LABEL,
-		precondition: ExplorerResourceNotReadonlyContext
-	},
-	when: ExplorerFolderContext
-});
+// MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
+// 	group: 'navigation',
+// 	order: 6,
+// 	command: {
+// 		id: NEW_FOLDER_COMMAND_ID,
+// 		title: NEW_FOLDER_LABEL,
+// 		precondition: ExplorerResourceNotReadonlyContext
+// 	},
+// 	when: ExplorerFolderContext
+// });
 
 MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
 	group: 'navigation',

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -606,6 +606,7 @@ export class CloseGroupAction extends Action {
 	}
 }
 
+// MEMBRANE: we do not register this action in fileActions.contribution.ts
 export class FocusFilesExplorer extends Action2 {
 
 	static readonly ID = 'workbench.files.action.focusFilesExplorer';
@@ -629,12 +630,14 @@ export class FocusFilesExplorer extends Action2 {
 export class ShowActiveFileInExplorer extends Action2 {
 
 	static readonly ID = 'workbench.files.action.showActiveFileInExplorer';
-	static readonly LABEL = nls.localize('showInExplorer', "Reveal Active File in Explorer View");
+	// MEMBRANE: override to show file in Navigator instead of Explorer
+	static readonly LABEL = nls.localize('showInExplorer', "Reveal Active File in Navigator");
 
 	constructor() {
 		super({
 			id: ShowActiveFileInExplorer.ID,
-			title: { value: ShowActiveFileInExplorer.LABEL, original: 'Reveal Active File in Explorer View' },
+			// MEMBRANE: override to show file in Navigator instead of Explorer
+			title: { value: ShowActiveFileInExplorer.LABEL, original: 'Reveal Active File in Navigator' },
 			f1: true,
 			category: Categories.File
 		});

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -9,7 +9,8 @@ import * as perf from 'vs/base/common/performance';
 import { WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification } from 'vs/base/common/actions';
 import { memoize } from 'vs/base/common/decorators';
 import { IFilesConfiguration, ExplorerFolderContext, FilesExplorerFocusedContext, ExplorerFocusedContext, ExplorerRootContext, ExplorerResourceReadonlyContext, ExplorerResourceCut, ExplorerResourceMoveableToTrash, ExplorerCompressedFocusContext, ExplorerCompressedFirstFocusContext, ExplorerCompressedLastFocusContext, ExplorerResourceAvailableEditorIdsContext, VIEW_ID, ExplorerResourceNotReadonlyContext, ViewHasSomeCollapsibleRootItemContext, FoldersViewVisibleContext } from 'vs/workbench/contrib/files/common/files';
-import { FileCopiedContext, NEW_FILE_COMMAND_ID, NEW_FOLDER_COMMAND_ID } from 'vs/workbench/contrib/files/browser/fileActions';
+// MEMBRANE: rm NEW_FOLDER_COMMAND_ID import
+import { FileCopiedContext, NEW_FILE_COMMAND_ID } from 'vs/workbench/contrib/files/browser/fileActions';
 import * as DOM from 'vs/base/browser/dom';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { ExplorerDecorationsProvider } from 'vs/workbench/contrib/files/browser/views/explorerDecorationsProvider';
@@ -44,7 +45,8 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 import { Event } from 'vs/base/common/event';
 import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 import { IViewDescriptorService } from 'vs/workbench/common/views';
-import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
+// MEMBRANE: rm IViewsService import
+// import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { EditorResourceAccessor, SideBySideEditor } from 'vs/workbench/common/editor';
@@ -1000,75 +1002,79 @@ registerAction2(class extends Action2 {
 	}
 });
 
-registerAction2(class extends Action2 {
-	constructor() {
-		super({
-			id: 'workbench.files.action.createFolderFromExplorer',
-			title: nls.localize('createNewFolder', "New Folder..."),
-			f1: false,
-			icon: Codicon.newFolder,
-			precondition: ExplorerResourceNotReadonlyContext,
-			menu: {
-				id: MenuId.ViewTitle,
-				group: 'navigation',
-				when: ContextKeyExpr.equals('view', VIEW_ID),
-				order: 20
-			}
-		});
-	}
+/**
+ * MEMBRANE: no need to register these explorer/file actions
+ */
 
-	run(accessor: ServicesAccessor): void {
-		const commandService = accessor.get(ICommandService);
-		commandService.executeCommand(NEW_FOLDER_COMMAND_ID);
-	}
-});
+// registerAction2(class extends Action2 {
+// 	constructor() {
+// 		super({
+// 			id: 'workbench.files.action.createFolderFromExplorer',
+// 			title: nls.localize('createNewFolder', "New Folder..."),
+// 			f1: false,
+// 			icon: Codicon.newFolder,
+// 			precondition: ExplorerResourceNotReadonlyContext,
+// 			menu: {
+// 				id: MenuId.ViewTitle,
+// 				group: 'navigation',
+// 				when: ContextKeyExpr.equals('view', VIEW_ID),
+// 				order: 20
+// 			}
+// 		});
+// 	}
 
-registerAction2(class extends Action2 {
-	constructor() {
-		super({
-			id: 'workbench.files.action.refreshFilesExplorer',
-			title: { value: nls.localize('refreshExplorer', "Refresh Explorer"), original: 'Refresh Explorer' },
-			f1: true,
-			icon: Codicon.refresh,
-			menu: {
-				id: MenuId.ViewTitle,
-				group: 'navigation',
-				when: ContextKeyExpr.equals('view', VIEW_ID),
-				order: 30
-			}
-		});
-	}
+// 	run(accessor: ServicesAccessor): void {
+// 		const commandService = accessor.get(ICommandService);
+// 		commandService.executeCommand(NEW_FOLDER_COMMAND_ID);
+// 	}
+// });
 
-	async run(accessor: ServicesAccessor): Promise<void> {
-		const viewsService = accessor.get(IViewsService);
-		const explorerService = accessor.get(IExplorerService);
-		await viewsService.openView(VIEW_ID);
-		await explorerService.refresh();
-	}
-});
+// registerAction2(class extends Action2 {
+// 	constructor() {
+// 		super({
+// 			id: 'workbench.files.action.refreshFilesExplorer',
+// 			title: { value: nls.localize('refreshExplorer', "Refresh Explorer"), original: 'Refresh Explorer' },
+// 			f1: true,
+// 			icon: Codicon.refresh,
+// 			menu: {
+// 				id: MenuId.ViewTitle,
+// 				group: 'navigation',
+// 				when: ContextKeyExpr.equals('view', VIEW_ID),
+// 				order: 30
+// 			}
+// 		});
+// 	}
 
-registerAction2(class extends Action2 {
-	constructor() {
-		super({
-			id: 'workbench.files.action.collapseExplorerFolders',
-			title: { value: nls.localize('collapseExplorerFolders', "Collapse Folders in Explorer"), original: 'Collapse Folders in Explorer' },
-			f1: true,
-			icon: Codicon.collapseAll,
-			menu: {
-				id: MenuId.ViewTitle,
-				group: 'navigation',
-				when: ContextKeyExpr.equals('view', VIEW_ID),
-				order: 40
-			}
-		});
-	}
+// 	async run(accessor: ServicesAccessor): Promise<void> {
+// 		const viewsService = accessor.get(IViewsService);
+// 		const explorerService = accessor.get(IExplorerService);
+// 		await viewsService.openView(VIEW_ID);
+// 		await explorerService.refresh();
+// 	}
+// });
 
-	run(accessor: ServicesAccessor) {
-		const viewsService = accessor.get(IViewsService);
-		const view = viewsService.getViewWithId(VIEW_ID);
-		if (view !== null) {
-			const explorerView = view as ExplorerView;
-			explorerView.collapseAll();
-		}
-	}
-});
+// registerAction2(class extends Action2 {
+// 	constructor() {
+// 		super({
+// 			id: 'workbench.files.action.collapseExplorerFolders',
+// 			title: { value: nls.localize('collapseExplorerFolders', "Collapse Folders in Explorer"), original: 'Collapse Folders in Explorer' },
+// 			f1: true,
+// 			icon: Codicon.collapseAll,
+// 			menu: {
+// 				id: MenuId.ViewTitle,
+// 				group: 'navigation',
+// 				when: ContextKeyExpr.equals('view', VIEW_ID),
+// 				order: 40
+// 			}
+// 		});
+// 	}
+
+// 	run(accessor: ServicesAccessor) {
+// 		const viewsService = accessor.get(IViewsService);
+// 		const view = viewsService.getViewWithId(VIEW_ID);
+// 		if (view !== null) {
+// 			const explorerView = view as ExplorerView;
+// 			explorerView.collapseAll();
+// 		}
+// 	}
+// });


### PR DESCRIPTION
1. rm `EXPLORER` sidebar flash on login and signup
2. rm commands that open the file explorer*
    1. rm `View: Show Explorer` command
    2. rm `Files: Focus on Files Explorer` command
    3. rm `Explorer: Focus on Folders View`
    4. rm `Explorer: Focus on Open Editors View`
    5. rm `Refresh Explorer`
    6. rm `Collapse Folders in Explorer`

_*I left the file outline and timeline there for now_

## Before

https://github.com/user-attachments/assets/3051f902-9243-4fc4-8eb0-7706368638c7

## After

https://github.com/user-attachments/assets/8fce27a9-123a-4fbd-9fbd-6f6d43d0376a