### PR TITLE
Add `typescript.provideRenameEdits` to integrate typescript renames into Membrane's `RenameProvider`

### DIFF
--- a/extensions/typescript-language-features/src/commands/index.ts
+++ b/extensions/typescript-language-features/src/commands/index.ts
@@ -3,11 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationToken, Position, TextDocument } from 'vscode';
+import { TypeScriptRenameProvider } from '../languageFeatures/rename';
 import { PluginManager } from '../tsServer/plugins';
 import TypeScriptServiceClientHost from '../typeScriptServiceClientHost';
 import { ActiveJsTsEditorTracker } from '../ui/activeJsTsEditorTracker';
 import { Lazy } from '../utils/lazy';
-import { CommandManager } from './commandManager';
+import { Command, CommandManager } from './commandManager';
 import { ConfigurePluginCommand } from './configurePlugin';
 import { JavaScriptGoToProjectConfigCommand, TypeScriptGoToProjectConfigCommand } from './goToProjectConfiguration';
 import { LearnMoreAboutRefactoringsCommand } from './learnMoreAboutRefactorings';
@@ -35,4 +37,14 @@ export function registerBaseCommands(
 	commandManager.register(new LearnMoreAboutRefactoringsCommand());
 	commandManager.register(new TSServerRequestCommand(lazyClientHost));
 	commandManager.register(new OpenJsDocLinkCommand());
+
+	// MEMBRANE: added this command to get typescript renames from our own RenameProvider
+	class ProvideRenameEditsCommand implements Command {
+		public readonly id = 'typescript.provideRenameEdits';
+
+		public async execute(document: TextDocument, position: Position, newName: string, token: CancellationToken) {
+			return await TypeScriptRenameProvider.instance?.provideRenameEdits(document, position, newName, token);
+		}
+	}
+	commandManager.register(new ProvideRenameEditsCommand());
 }

--- a/extensions/typescript-language-features/src/languageFeatures/rename.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/rename.ts
@@ -23,13 +23,17 @@ type RenameResponse = {
 	readonly spans: readonly Proto.TextSpan[];
 };
 
-class TypeScriptRenameProvider implements vscode.RenameProvider {
+// MEMBRANE: added `instance` to get typescript renames from our own RenameProvider
+export class TypeScriptRenameProvider implements vscode.RenameProvider {
+	public static instance: TypeScriptRenameProvider | undefined = undefined;
 
 	public constructor(
 		private readonly language: LanguageDescription,
 		private readonly client: ITypeScriptServiceClient,
 		private readonly fileConfigurationManager: FileConfigurationManager
-	) { }
+	) {
+		TypeScriptRenameProvider.instance = this;
+	}
 
 	public async prepareRename(
 		document: vscode.TextDocument,


### PR DESCRIPTION
Context: https://github.com/membrane-io/mnode/pull/397#discussion_r1900231491
