### PR TITLE
Remove action title text truncation

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -105,9 +105,10 @@
 }
 
 .action-widget .monaco-list-row.action .title {
-	flex: 1;
+	/* Don't let action title truncate so we can see the full title */
+	/* flex: 1;
 	overflow: hidden;
-	text-overflow: ellipsis;
+	text-overflow: ellipsis; */
 }
 
 .action-widget .monaco-list-row.action .monaco-keybinding > .monaco-keybinding-key {

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -105,7 +105,7 @@
 }
 
 .action-widget .monaco-list-row.action .title {
-	/* Don't let action title truncate so we can see the full title */
+	/* MEMBRANE: Don't let action title truncate so we can see the full title */
 	/* flex: 1;
 	overflow: hidden;
 	text-overflow: ellipsis; */


### PR DESCRIPTION
Now the quick fix action title text won't truncate, and we can see the full "Declare ... {type}"

Related: https://github.com/membrane-io/mnode/pull/412