### PR TITLE
Silence `Bad progress location: workbench.scm`

### DIFF
--- a/src/vs/workbench/services/progress/browser/progressService.ts
+++ b/src/vs/workbench/services/progress/browser/progressService.ts
@@ -61,6 +61,12 @@ export class ProgressService extends Disposable implements IProgressService {
 				return this.withViewProgress(location, task, { ...options, location });
 			}
 
+			// MEMBRANE: SCM is disabled, so let's silence the error below
+			if (location === 'workbench.scm') {
+				// no-op progress that resolves immediately
+				return task({ report: () => { } });
+			}
+
 			throw new Error(`Bad progress location: ${location}`);
 		};
 


### PR DESCRIPTION
We removed SCM from the activity bar, so I don't think we need the progress service to track it.