### PR TITLE
T-1342: add command to emit event for product tour

### DIFF
--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -59,6 +59,10 @@ type Writeable<T> = { -readonly [P in keyof T]: T[P] };
 		{
 			id: 'membrane.completeInitialization', handler: () => window.completeInitialization?.()
 		},
+		// For product tour, emit an event to advance to the next step
+		{
+			id: 'membrane.advanceTour', handler: (event) => window.dispatchEvent(new Event(`membrane-tour:${event.trigger}`))
+		},
 		{
 			id: 'membrane.getLaunchParams', handler: () => {
 				// eslint-disable-next-line no-restricted-syntax

--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -61,7 +61,7 @@ type Writeable<T> = { -readonly [P in keyof T]: T[P] };
 		},
 		// For product tour, emit an event to advance to the next step
 		{
-			id: 'membrane.advanceTour', handler: (event) => window.dispatchEvent(new Event(`membrane-tour:${event.trigger}`))
+			id: 'membrane.advanceTour', handler: (event) => window.dispatchEvent(new Event(`tour:${event.trigger}`))
 		},
 		{
 			id: 'membrane.getLaunchParams', handler: () => {

--- a/src/vs/workbench/contrib/url/browser/trustedDomains.ts
+++ b/src/vs/workbench/contrib/url/browser/trustedDomains.ts
@@ -210,7 +210,7 @@ export function readStaticTrustedDomains(accessor: ServicesAccessor): IStaticTru
 	const defaultTrustedDomains = [
 		// MEMBRANE: add membrane trusted domains to skip confirmation dialog
 		'https://membrane.io',
-		'https://docs.membrane.io',
+		'https://*.membrane.io',
 		...productService.linkProtectionTrustedDomains ?? [],
 		...environmentService.options?.additionalTrustedDomains ?? []
 	];


### PR DESCRIPTION
See https://github.com/membrane-io/mnode/pull/485

1. Adds vscode command that emits an event for the tour
2. Configures membrane.io subdomains as trusted