### PR TITLE
Use `typescript` fork to get contextual typing of exports

### DIFF
--- a/extensions/package.json
+++ b/extensions/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "description": "Dependencies shared by all extensions",
   "dependencies": {
-    "typescript": "5.3.2"
+    "typescript": "npm:@membrane/typescript@5.3.2-3"
   },
   "scripts": {
     "postinstall": "node ./postinstall.mjs"

--- a/extensions/package.json
+++ b/extensions/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "description": "Dependencies shared by all extensions",
   "dependencies": {
-    "typescript": "npm:@membrane/typescript@5.3.2-3"
+    "typescript": "npm:@membrane/typescript@5.3.2-4"
   },
   "scripts": {
     "postinstall": "node ./postinstall.mjs"

--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -228,10 +228,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-typescript@5.3.2:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.2.tgz#00d1c7c1c46928c5845c1ee8d0cc2791031d4c43"
-  integrity sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==
+"typescript@npm:@membrane/typescript@5.3.2-3":
+  version "5.3.2-3"
+  resolved "https://registry.yarnpkg.com/@membrane/typescript/-/typescript-5.3.2-3.tgz#453c10a2409f0a4d22f54d4520a42f479d2de229"
+  integrity sha512-p55t4jk0F+g18VVu2Ecv00X/J4GuUIrg1htv90S7vcGksHzxnZ64mVHWigUxvevsET+Tc9+fflgDbWMHK7G8LA==
 
 vscode-grammar-updater@^1.1.0:
   version "1.1.0"

--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -228,10 +228,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-"typescript@npm:@membrane/typescript@5.3.2-3":
-  version "5.3.2-3"
-  resolved "https://registry.yarnpkg.com/@membrane/typescript/-/typescript-5.3.2-3.tgz#453c10a2409f0a4d22f54d4520a42f479d2de229"
-  integrity sha512-p55t4jk0F+g18VVu2Ecv00X/J4GuUIrg1htv90S7vcGksHzxnZ64mVHWigUxvevsET+Tc9+fflgDbWMHK7G8LA==
+"typescript@npm:@membrane/typescript@5.3.2-4":
+  version "5.3.2-4"
+  resolved "https://registry.yarnpkg.com/@membrane/typescript/-/typescript-5.3.2-4.tgz#3b4d12b43a0227eed898c2d72a2f4f7b9a8daee3"
+  integrity sha512-J/Jy6xbTsn/BFMjbG2Pt06888HhXkAgcK8jY7SEbC8AypTmjNMlV7LpGFKgYEGOd4jUtPYbEisehbcu2D34NmQ==
 
 vscode-grammar-updater@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
See: https://github.com/membrane-io/mnode/pull/491