### PR TITLE
Allow us to combine program overview and assistant. Thinner tabs

### DIFF
--- a/src/vs/workbench/api/browser/viewsExtensionPoint.ts
+++ b/src/vs/workbench/api/browser/viewsExtensionPoint.ts
@@ -343,7 +343,6 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
 		const viewContainersRegistry = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry);
 		let activityBarOrder = CUSTOM_VIEWS_START_ORDER + viewContainersRegistry.all.filter(v => !!v.extensionId && viewContainersRegistry.getViewContainerLocation(v) === ViewContainerLocation.Sidebar).length;
 		let panelOrder = 5 + viewContainersRegistry.all.filter(v => !!v.extensionId && viewContainersRegistry.getViewContainerLocation(v) === ViewContainerLocation.Panel).length + 1;
-		let auxiliaryBarOrder = 0;
 		for (const { value, collector, description } of extensionPoints) {
 			Object.entries(value).forEach(([key, value]) => {
 				if (!this.isValidViewsContainer(value, collector)) {
@@ -360,15 +359,6 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
 						// MEMBRANE: ensure Logs are first in panel (bottom pane)
 						const order = description.identifier.value === 'membrane.membrane' ? 0 : panelOrder;
 						panelOrder = this.registerCustomViewContainers(value, description, order, existingViewContainers, ViewContainerLocation.Panel);
-						break;
-					}
-					case 'auxiliarybar': {
-						// MEMBRANE: handle multiple auxiliary bar containers (right sidebar)
-						const order = value?.some(v =>
-							v.id === 'membraneProgramContainer' ||
-							v.id === 'membraneAssistantContainer'
-						) ? 0 : auxiliaryBarOrder;
-						auxiliaryBarOrder = this.registerCustomViewContainers(value, description, order, existingViewContainers, ViewContainerLocation.AuxiliaryBar);
 						break;
 					}
 				}
@@ -434,13 +424,12 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
 			}
 
 			// MEMBRANE: move Program Overview to auxiliary bar (right-side bar)
-			// We don't need this anymore since we added the auxiliary bar case to the default view container
-			// const overridenLocation = descriptor.id === 'membraneAuxContainer' ? ViewContainerLocation.AuxiliaryBar : location;
+			const overridenLocation = descriptor.id === 'membraneAuxContainer' ? ViewContainerLocation.AuxiliaryBar : location;
 
 			const icon = themeIcon || resources.joinPath(extension.extensionLocation, descriptor.icon);
 			const id = `workbench.view.extension.${descriptor.id}`;
 			const title = descriptor.title || id;
-			const viewContainer = this.registerCustomViewContainer(id, title, icon, order++, extension.identifier, location, options);
+			const viewContainer = this.registerCustomViewContainer(id, title, icon, order++, extension.identifier, overridenLocation, options);
 
 			// Move those views that belongs to this container
 			if (existingViewContainers.length) {

--- a/src/vs/workbench/browser/part.ts
+++ b/src/vs/workbench/browser/part.ts
@@ -152,7 +152,8 @@ export abstract class Part extends Component implements ISerializableView {
 
 class PartLayout {
 
-	private static readonly TITLE_HEIGHT = 35;
+	// MEMBRANE: thinner editor tabs (not really needed because we don't show them, but for consistency with css)
+	private static readonly TITLE_HEIGHT = 30;
 
 	constructor(private options: IPartOptions, private contentArea: HTMLElement | undefined) { }
 

--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
@@ -84,7 +84,8 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 		super(
 			Parts.AUXILIARYBAR_PART,
 			{
-				hasTitle: true,
+				// MEMBRANE: hide title area for auxiliary bar
+				hasTitle: false,
 				borderWidth: () => (this.getColor(SIDE_BAR_BORDER) || this.getColor(contrastBorder)) ? 1 : 0,
 			},
 			AuxiliaryBarPart.activePanelSettingsKey,

--- a/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
@@ -144,7 +144,8 @@
 
 .monaco-workbench .part.editor > .content .editor-group-container > .editor-group-container-toolbar {
 	display: none;
-	height: 35px;
+	/* MEMBRANE: thinner editor tabs */
+	height: 30px;
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container.empty.locked > .editor-group-container-toolbar,

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -438,10 +438,13 @@
 
 /* Editor Actions Toolbar */
 
+/* MEMBRANE: These changes allows us to have two toolbars in the editor title for the show aux bar button */
 .monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions {
+	display: flex;
+	flex-direction: row;
 	cursor: default;
 	flex: initial;
-	padding: 0 8px 0 4px;
+	padding: 0 0 0 4px;
 	height: var(--editor-group-tab-height);
 }
 
@@ -465,4 +468,21 @@
 
 	/* When multiple tab bars are visible, only show editor actions for the last tab bar */
 	display: none;
+}
+
+/* MEMBRANE: Positioning of button to open the aux bar so that it matches gaze's */
+.monaco-workbench .actions-container[aria-label="Additional Editor actions"] .menu-entry {
+	margin-right: 0px !important;
+}
+.monaco-workbench .actions-container[aria-label="Additional Editor actions"] .codicon-chevron-left {
+	border-radius: 0px;
+	padding: 7px;
+	margin-bottom: 0px;
+}
+.monaco-workbench .actions-container[aria-label="Additional Editor actions"] .disabled {
+	margin-right: 0px !important;
+}
+.monaco-workbench .actions-container[aria-label="Additional Editor actions"] .separator {
+	height: 30px;
+	opacity: 0.25;
 }

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -56,6 +56,7 @@ import { IEditorTitleControlDimensions } from 'vs/workbench/browser/parts/editor
 import { StickyEditorGroupModel, UnstickyEditorGroupModel } from 'vs/workbench/common/editor/filteredEditorGroupModel';
 import { IReadonlyEditorGroupModel } from 'vs/workbench/common/editor/editorGroupModel';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 
 interface IEditorInputLabel {
 	readonly editor: EditorInput;
@@ -149,9 +150,10 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		@IPathService private readonly pathService: IPathService,
 		@ITreeViewsDnDService private readonly treeViewsDragAndDropService: ITreeViewsDnDService,
 		@IEditorResolverService editorResolverService: IEditorResolverService,
-		@IHostService hostService: IHostService
+		@IHostService hostService: IHostService,
+		@ICommandService commandService: ICommandService
 	) {
-		super(parent, editorPartsView, groupsView, groupView, tabsModel, contextMenuService, instantiationService, contextKeyService, keybindingService, notificationService, quickInputService, themeService, editorResolverService, hostService);
+		super(parent, editorPartsView, groupsView, groupView, tabsModel, contextMenuService, instantiationService, contextKeyService, keybindingService, notificationService, quickInputService, themeService, editorResolverService, hostService, commandService);
 
 		// Resolve the correct path library for the OS we are on
 		// If we are connected to remote, this accounts for the

--- a/src/vs/workbench/browser/parts/media/compositepart.css
+++ b/src/vs/workbench/browser/parts/media/compositepart.css
@@ -11,10 +11,11 @@
 	display: flex;
 }
 
-/* MEMBRANE: add back composite title except for Navigator and Logs */
+/* MEMBRANE: add back composite title except for some Membrane views */
 .monaco-workbench .part:has(.content > .composite:not(
 	[id="workbench.view.extension.membraneContainer"],
-	[id="workbench.view.extension.membraneLogs"]
+	[id="workbench.view.extension.membraneLogs"],
+	[id="workbench.view.extension.membraneAuxContainer"]
 )) {
 	height: 100% !important;
 


### PR DESCRIPTION
See: https://github.com/membrane-io/mnode/pull/506

 - Reverted #49 so we can combine program overview and assistant in one gaze instance
 - Made tabs a tad thinner so that our explorer buttons don't have to be so massive
 
 BEFORE
![Screenshot 2025-03-02 at 02 49 13](https://github.com/user-attachments/assets/ff83936e-60b2-4e40-9102-106e915ec21e)


AFTER
![Screenshot 2025-03-02 at 02 48 04](https://github.com/user-attachments/assets/46797ff9-f45a-4cee-a756-fcaa1384ff74)

 - Added this button to open aux bar
![Screenshot 2025-03-02 at 02 46 02](https://github.com/user-attachments/assets/61cbab61-3519-4a08-9757-7ceeb2b6f674)

