### PR TITLE
Remove stray red color for `*.async`

### DIFF
--- a/extensions/theme-defaults/themes/membrane_dark.json
+++ b/extensions/theme-defaults/themes/membrane_dark.json
@@ -687,6 +687,5 @@
 		"stringLiteral": "#ececec",
 		"customLiteral": "#ececec",
 		"numberLiteral": "#ececec",
-		"*.async": "#ff0000"
 	}
 }


### PR DESCRIPTION
Fixes this

![Screenshot 2025-03-04 at 15 52 18](https://github.com/user-attachments/assets/e4740486-145a-4bc9-abc3-0e47dcdb970f)
