### PR TITLE
Add `Dashboard` button next to open aux bar button

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -1024,6 +1024,13 @@ function registerCloseEditorCommands() {
 			}
 
 			if (group) {
+				// MEMBRANE: prevent closing dashboard
+				const dashboard = group.editors.find(e => e.getTitle() === 'Dashboard');
+				if (dashboard) {
+					group.closeAllEditors(); // Method modified to not close dashboard
+					return;
+				}
+
 				editorGroupService.removeGroup(group);
 			}
 		}

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -1373,6 +1373,11 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 			return false;
 		}
 
+		// MEMBRANE: prevent closing dashboard
+		if (editor.getTitle() === 'Dashboard') {
+			return false;
+		}
+
 		// Check for confirmation and veto
 		const veto = await this.handleCloseConfirmation([editor]);
 		if (veto) {
@@ -1698,7 +1703,8 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 			return true;
 		}
 
-		const editors = this.doGetEditorsToClose(args);
+		// MEMBRANE: prevent closing dashboard
+		const editors = this.doGetEditorsToClose(args).filter(e => e.getTitle() !== 'Dashboard');
 
 		// Check for confirmation and veto
 		const veto = await this.handleCloseConfirmation(editors.slice(0));
@@ -1798,7 +1804,9 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 		// Close all inactive editors first
 		const editorsToClose: EditorInput[] = [];
-		for (const editor of this.model.getEditors(EditorsOrder.SEQUENTIAL, options)) {
+
+		// MEMBRANE: prevent closing dashboard
+		for (const editor of this.model.getEditors(EditorsOrder.SEQUENTIAL, options).filter(e => e.getTitle() !== 'Dashboard')) {
 			if (!this.isActive(editor)) {
 				this.doCloseInactiveEditor(editor);
 			}

--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -8,7 +8,9 @@ import { localize } from 'vs/nls';
 import { applyDragImage, DataTransfers } from 'vs/base/browser/dnd';
 import { Dimension, getActiveWindow, getWindow, isMouseEvent } from 'vs/base/browser/dom';
 import { StandardMouseEvent } from 'vs/base/browser/mouseEvent';
-import { ActionsOrientation, IActionViewItem, prepareActions } from 'vs/base/browser/ui/actionbar/actionbar';
+// MEMBRANE: hide editor tab actions (e.g. Split Editor, More Actions)
+// import { prepareActions } from 'vs/base/browser/ui/actionbar/actionbar';
+import { ActionsOrientation, IActionViewItem } from 'vs/base/browser/ui/actionbar/actionbar';
 import { IAction, ActionRunner } from 'vs/base/common/actions';
 import { ResolvedKeybinding } from 'vs/base/common/keybindings';
 import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
@@ -265,12 +267,17 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 	// MEMBRANE: see membraneActionsToolbar initialization above
 	private updateMembraneActions() {
 		const membraneActions: IAction[] = [];
-		const show = this.contextKeyService.contextMatchesRules(AuxiliaryBarVisibleContext.toNegated());
-		if (show) {
+		membraneActions.push(new MenuItemAction({
+			id: 'membrane.dashboard.show',
+			title: 'Dashboard',
+		}, undefined, undefined, undefined, this.contextKeyService, this.commandService));
+
+		const isAuxBarHidden = this.contextKeyService.contextMatchesRules(AuxiliaryBarVisibleContext.toNegated());
+		if (isAuxBarHidden) {
 			membraneActions.push(new Separator());
 			membraneActions.push(new MenuItemAction({
 				id: 'workbench.action.toggleAuxiliaryBar',
-				title: 'Show Auxiliary Bar',
+				title: 'Show Brane (AI) & Program Info',
 				icon: Codicon.chevronLeft,
 			}, undefined, undefined, undefined, this.contextKeyService, this.commandService));
 		}
@@ -303,11 +310,10 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 		const editorActions = this.groupView.createEditorActions(this.editorActionsDisposables);
 		this.editorActionsDisposables.add(editorActions.onDidChange(() => this.updateEditorActionsToolbar()));
 
-		const editorActionsToolbar = assertIsDefined(this.editorActionsToolbar);
-		const { primary, secondary } = this.prepareEditorActions(editorActions.actions);
-		editorActionsToolbar.setActions(prepareActions(primary), prepareActions(secondary));
-
-
+		// MEMBRANE: hide editor tab actions (e.g. Split Editor, More Actions)
+		// const editorActionsToolbar = assertIsDefined(this.editorActionsToolbar);
+		// const { primary, secondary } = this.prepareEditorActions(editorActions.actions);
+		// editorActionsToolbar.setActions(prepareActions(primary), prepareActions(secondary));
 	}
 
 	protected abstract prepareEditorActions(editorActions: IToolbarActions): IToolbarActions;

--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -269,7 +269,8 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 		const membraneActions: IAction[] = [];
 		membraneActions.push(new MenuItemAction({
 			id: 'membrane.dashboard.show',
-			title: 'Dashboard',
+			title: 'Show Dashboard',
+			icon: Codicon.symbolEnum,
 		}, undefined, undefined, undefined, this.contextKeyService, this.commandService));
 
 		const isAuxBarHidden = this.contextKeyService.contextMatchesRules(AuxiliaryBarVisibleContext.toNegated());

--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -26,7 +26,7 @@ import { listActiveSelectionBackground, listActiveSelectionForeground } from 'vs
 import { IThemeService, Themable } from 'vs/platform/theme/common/themeService';
 import { DraggedEditorGroupIdentifier, DraggedEditorIdentifier, fillEditorsDragData, isWindowDraggedOver } from 'vs/workbench/browser/dnd';
 import { EditorPane } from 'vs/workbench/browser/parts/editor/editorPane';
-import { IEditorGroupsView, IEditorGroupView, IEditorPartsView, IInternalEditorOpenOptions } from 'vs/workbench/browser/parts/editor/editor';
+import { EditorServiceImpl, IEditorGroupsView, IEditorGroupView, IEditorPartsView, IInternalEditorOpenOptions } from 'vs/workbench/browser/parts/editor/editor';
 import { IEditorCommandsContext, EditorResourceAccessor, IEditorPartOptions, SideBySideEditor, EditorsOrder, EditorInputCapabilities, IToolbarActions, GroupIdentifier } from 'vs/workbench/common/editor';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { ResourceContextKey, ActiveEditorPinnedContext, ActiveEditorStickyContext, ActiveEditorGroupLockedContext, ActiveEditorCanSplitInGroupContext, SideBySideEditorActiveContext, ActiveEditorFirstInGroupContext, ActiveEditorAvailableEditorIdsContext, applyAvailableEditorIds, ActiveEditorLastInGroupContext } from 'vs/workbench/common/contextkeys';
@@ -54,6 +54,7 @@ import { Separator } from 'vs/base/common/actions';
 import { AuxiliaryBarVisibleContext } from 'vs/workbench/common/contextkeys';
 import { Codicon } from 'vs/base/common/codicons';
 import { ICommandService } from 'vs/platform/commands/common/commands';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
 export class EditorCommandsContextActionRunner extends ActionRunner {
 
@@ -148,7 +149,9 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 		@IThemeService themeService: IThemeService,
 		@IEditorResolverService private readonly editorResolverService: IEditorResolverService,
 		@IHostService private readonly hostService: IHostService,
-		@ICommandService private readonly commandService: ICommandService
+		// MEMBRANE: inject command and editor services
+		@ICommandService private readonly commandService: ICommandService,
+		@IEditorService protected readonly editorService: EditorServiceImpl,
 	) {
 		super(themeService);
 
@@ -261,16 +264,23 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 				this.updateMembraneActions();
 			}
 		}));
+		// Update when the active editor changes
+		this.editorActionsToolbarDisposables.add(this.editorService.onDidActiveEditorChange(() => {
+			this.updateMembraneActions();
+		}));
 		this.updateMembraneActions();
 	}
 
 	// MEMBRANE: see membraneActionsToolbar initialization above
 	private updateMembraneActions() {
 		const membraneActions: IAction[] = [];
+
+		const isDashboardShowing = this.groupView.activeEditor?.getName() === 'Dashboard';
+		membraneActions.push(new Separator());
 		membraneActions.push(new MenuItemAction({
 			id: 'membrane.dashboard.show',
-			title: 'Show Dashboard',
-			icon: Codicon.symbolEnum,
+			title: 'Dashboard',
+			tooltip: isDashboardShowing ? 'Viewing Dashboard' : 'Show Dashboard',
 		}, undefined, undefined, undefined, this.contextKeyService, this.commandService));
 
 		const isAuxBarHidden = this.contextKeyService.contextMatchesRules(AuxiliaryBarVisibleContext.toNegated());

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -440,11 +440,11 @@
 
 /* MEMBRANE: These changes allows us to have two toolbars in the editor title for the show aux bar button */
 .monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions {
-	display: flex;
-	flex-direction: row;
+	display: flex; /* MEMBRANE: */
+	flex-direction: row; /* MEMBRANE: */
 	cursor: default;
 	flex: initial;
-	padding: 0 0 0 4px;
+	padding: 0 0 0 4px; /* MEMBRANE: */
 	height: var(--editor-group-tab-height);
 }
 
@@ -470,19 +470,38 @@
 	display: none;
 }
 
-/* MEMBRANE: Positioning of button to open the aux bar so that it matches gaze's */
-.monaco-workbench .actions-container[aria-label="Additional Editor actions"] .menu-entry {
-	margin-right: 0px !important;
-}
-.monaco-workbench .actions-container[aria-label="Additional Editor actions"] .codicon-chevron-left {
-	border-radius: 0px;
-	padding: 7px;
-	margin-bottom: 0px;
-}
-.monaco-workbench .actions-container[aria-label="Additional Editor actions"] .disabled {
-	margin-right: 0px !important;
-}
-.monaco-workbench .actions-container[aria-label="Additional Editor actions"] .separator {
-	height: 30px;
-	opacity: 0.25;
+/* MEMBRANE: editor actions toolbar changes */
+.monaco-workbench .actions-container[aria-label="Additional Editor actions"] {
+	.action-item {
+		margin-right: 0px !important;
+		
+		/* Show Dashboard button */
+		&.menu-entry[title="Dashboard"] {
+			a[aria-label="Dashboard"] {
+				border-radius: 0px;
+				padding: 7px;
+				margin-bottom: 0px;
+			}
+		}
+	
+		/* Separator vertical line */
+		&.disabled {
+			.separator {
+				/* Note: margin on this element in actionbar.css also uses !important, but this declaration has higher specificity */
+				margin: 0 !important;
+				width: 1px;
+				height: 30px;
+				opacity: 0.25;
+			}
+		}
+	
+		/* Positioning of button to open the aux bar so that it matches gaze's */
+		&.menu-entry[title="Show Brane (AI) & Program Info (⌥⌘B)"] {
+			a.codicon-chevron-left {
+				border-radius: 0px;
+				padding: 7px;
+				margin-bottom: 0px;
+			}
+		}
+	}
 }

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -481,8 +481,9 @@
 		margin-right: 0px !important;
 		
 		/* Show Dashboard button */
-		&.menu-entry[title="Dashboard"] {
-			a[aria-label="Dashboard"] {
+		&.menu-entry[title="Show Dashboard"] {
+			a.codicon-symbol-enum {
+				color: inherit;
 				border-radius: 0px;
 				padding: 7px;
 				margin-bottom: 0px;

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -104,6 +104,11 @@
 	height: var(--editor-group-tab-height);
 	box-sizing: border-box;
 	padding-left: 10px;
+
+	/* MEMBRANE: always hide dashboard tab */
+	&[title="Dashboard"] {
+		display: none;
+	}
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .tabs-container > .tab:last-child {
@@ -438,7 +443,7 @@
 
 /* Editor Actions Toolbar */
 
-/* MEMBRANE: These changes allows us to have two toolbars in the editor title for the show aux bar button */
+/* MEMBRANE: declarations with comments in this block allow us to have two toolbars in the editor title for the show aux bar button */
 .monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions {
 	display: flex; /* MEMBRANE: */
 	flex-direction: row; /* MEMBRANE: */

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -480,16 +480,6 @@
 	.action-item {
 		margin-right: 0px !important;
 		
-		/* Show Dashboard button */
-		&.menu-entry[title="Show Dashboard"] {
-			a.codicon-symbol-enum {
-				color: inherit;
-				border-radius: 0px;
-				padding: 7px;
-				margin-bottom: 0px;
-			}
-		}
-	
 		/* Separator vertical line */
 		&.disabled {
 			.separator {
@@ -498,6 +488,24 @@
 				width: 1px;
 				height: 30px;
 				opacity: 0.25;
+			}
+		}
+	
+		/* Show Dashboard button */
+		&.menu-entry[title="Show Dashboard"], &.menu-entry[title="Viewing Dashboard"] {
+			a {
+				border-radius: 0px;
+				padding-block: 7px;
+				padding-inline: 14px;
+				margin-bottom: 0px;
+
+				&:hover {
+					background-color: var(--vscode-button-secondaryHoverBackground);
+				}
+
+				&[aria-label="Viewing Dashboard"] {
+					background-color: var(--vscode-button-secondaryBackground);
+				}
 			}
 		}
 	

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -498,9 +498,15 @@
 				padding-block: 7px;
 				padding-inline: 14px;
 				margin-bottom: 0px;
+				transform: translateY(-1px);
 
 				&:hover {
 					background-color: var(--vscode-button-secondaryHoverBackground);
+				}
+
+				/* Match gaze inactive tab style */
+				&[aria-label="Show Dashboard"] {
+					opacity: 0.75;
 				}
 
 				&[aria-label="Viewing Dashboard"] {

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -146,14 +146,17 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		@INotificationService notificationService: INotificationService,
 		@IQuickInputService quickInputService: IQuickInputService,
 		@IThemeService themeService: IThemeService,
-		@IEditorService private readonly editorService: EditorServiceImpl,
+		// MEMBRANE: added editor service to base class, EditorTabsControl
+		// @IEditorService private readonly editorService: EditorServiceImpl,
 		@IPathService private readonly pathService: IPathService,
 		@ITreeViewsDnDService private readonly treeViewsDragAndDropService: ITreeViewsDnDService,
 		@IEditorResolverService editorResolverService: IEditorResolverService,
 		@IHostService hostService: IHostService,
-		@ICommandService commandService: ICommandService
+		// MEMBRANE: inject services for membrane tab actions bar
+		@ICommandService commandService: ICommandService,
+		@IEditorService editorService: EditorServiceImpl,
 	) {
-		super(parent, editorPartsView, groupsView, groupView, tabsModel, contextMenuService, instantiationService, contextKeyService, keybindingService, notificationService, quickInputService, themeService, editorResolverService, hostService, commandService);
+		super(parent, editorPartsView, groupsView, groupView, tabsModel, contextMenuService, instantiationService, contextKeyService, keybindingService, notificationService, quickInputService, themeService, editorResolverService, hostService, commandService, editorService);
 
 		// Resolve the correct path library for the OS we are on
 		// If we are connected to remote, this accounts for the


### PR DESCRIPTION
1. Add custom `Dashboard` tab next to aux bar
2. Hide split view and triple dot menu icon buttons
3. Hide Dashboard default editor tab
4. Prevent closing the dashboard editor