### PR TITLE
Ignore package.json created events.

### DIFF
--- a/extensions/typescript-language-features/web/src/serverHost.ts
+++ b/extensions/typescript-language-features/web/src/serverHost.ts
@@ -57,7 +57,36 @@ function createServerHost(
 	const textEncoder = new TextEncoder();
 
 	return {
-		watchFile: watchManager.watchFile.bind(watchManager),
+		watchFile: (
+			path: string,
+			callback: ts.FileWatcherCallback,
+			pollingInterval?: number,
+			options?: ts.WatchOptions,
+		): ts.FileWatcher => {
+			const wrappedCallback: ts.FileWatcherCallback = (
+				filePath: string,
+				eventKind: ts.FileWatcherEventKind,
+			) => {
+				// MEMBRANE: Ignore package.json created events, removed on typescript@v5.5
+				// https://github.com/microsoft/TypeScript/commit/f3f70df94e120bab69dd766bacd22089347b71c9
+				// only for memfs/ts-nul-authority/{program}/package.json
+				if (
+					filePath.endsWith("package.json") &&
+					/^\/memfs\/ts-nul-authority\/[^/]+\/package\.json$/.test(filePath) &&
+					eventKind === ts.FileWatcherEventKind.Created
+				) {
+					return;
+				}
+				callback(filePath, eventKind);
+			};
+
+			return watchManager.watchFile(
+				path,
+				wrappedCallback,
+				pollingInterval,
+				options,
+			);
+		},
 		watchDirectory: watchManager.watchDirectory.bind(watchManager),
 		setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): any {
 			return setTimeout(callback, ms, ...args);


### PR DESCRIPTION
_Problem 2: I have a website program. I delete it and then create a new one again with new -> website, but it throws those errors. This happens because tsserver internally has a watcher that detects the creation of package.json, but within the TypeScript code, there is a return Debug.fail();._

Ignore package.json created events, removed on typescript@v5.5

https://github.com/microsoft/TypeScript/commit/f3f70df94e120bab69dd766bacd22089347b71c9

![Captura de pantalla 2025-04-24 a la(s) 4 46 18 p m](https://github.com/user-attachments/assets/3890c3ec-b954-4f31-ab70-935938ded894)
![Captura de pantalla 2025-04-24 a la(s) 4 46 14 p m](https://github.com/user-attachments/assets/47dbf265-2d63-4ea3-9284-d13fe1be62db)
