### PR TITLE
WIP: semantic diagnostic delay (causing codelens slowness)

### DIFF
--- a/build/lib/tsb/builder.ts
+++ b/build/lib/tsb/builder.ts
@@ -99,6 +99,7 @@ export function createTypeScriptBuilder(config: IConfiguration, projectFile: str
 					if (!host.getScriptSnapshot(fileName, false)) {
 						resolve([]); // no script, no problems
 					} else {
+						console.log('tofu checkSemanticsSoon', Date.now());
 						resolve(service.getSemanticDiagnostics(fileName));
 					}
 				});

--- a/extensions/typescript-language-features/src/languageFeatures/codeLens/implementationsCodeLens.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/codeLens/implementationsCodeLens.ts
@@ -38,6 +38,8 @@ export default class TypeScriptImplementationsCodeLensProvider extends TypeScrip
 	): Promise<vscode.CodeLens> {
 		const args = typeConverters.Position.toFileLocationRequestArgs(codeLens.file, codeLens.range.start);
 		const response = await this.client.execute('implementation', args, token, {
+			// MEMBRANE
+			// lowPriority: false,
 			lowPriority: true,
 			executionTarget: ExecutionTarget.Semantic,
 			cancelOnResourceChange: codeLens.document,

--- a/extensions/typescript-language-features/src/languageFeatures/codeLens/referencesCodeLens.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/codeLens/referencesCodeLens.ts
@@ -35,6 +35,8 @@ export class TypeScriptReferencesCodeLensProvider extends TypeScriptBaseCodeLens
 	public async resolveCodeLens(codeLens: ReferencesCodeLens, token: vscode.CancellationToken): Promise<vscode.CodeLens> {
 		const args = typeConverters.Position.toFileLocationRequestArgs(codeLens.file, codeLens.range.start);
 		const response = await this.client.execute('references', args, token, {
+			// MEMBRANE
+			// lowPriority: false,
 			lowPriority: true,
 			executionTarget: ExecutionTarget.Semantic,
 			cancelOnResourceChange: codeLens.document,

--- a/extensions/typescript-language-features/src/tsServer/bufferSyncSupport.ts
+++ b/extensions/typescript-language-features/src/tsServer/bufferSyncSupport.ts
@@ -528,6 +528,7 @@ export default class BufferSyncSupport extends Disposable {
 			for (const { document } of e) {
 				const syncedBuffer = this.syncedBuffers.get(document.uri);
 				if (syncedBuffer) {
+					// This fires on load
 					this.requestDiagnostic(syncedBuffer);
 				}
 			}
@@ -600,6 +601,7 @@ export default class BufferSyncSupport extends Disposable {
 		const syncedBuffer = new SyncedBuffer(document, filepath, this.client, this.synchronizer);
 		this.syncedBuffers.set(resource, syncedBuffer);
 		syncedBuffer.open();
+		// This fires on load
 		this.requestDiagnostic(syncedBuffer);
 		return true;
 	}
@@ -684,7 +686,7 @@ export default class BufferSyncSupport extends Disposable {
 	}
 
 	private triggerDiagnostics(delay: number = 200) {
-		/// MEMBRNAE: make intellisense and ts-plugin respond faster by reducing the artificial delay.
+		/// MEMBRANE: make intellisense and ts-plugin respond faster by reducing the artificial delay.
 		delay = 50;
 		this.diagnosticDelayer.trigger(() => {
 			this.sendPendingDiagnostics();
@@ -692,6 +694,8 @@ export default class BufferSyncSupport extends Disposable {
 	}
 
 	private requestDiagnostic(buffer: SyncedBuffer): boolean {
+		console.log('tofu requestDiagnostic', Date.now());
+
 		if (!this.shouldValidate(buffer)) {
 			return false;
 		}

--- a/extensions/typescript-language-features/src/tsServer/server.ts
+++ b/extensions/typescript-language-features/src/tsServer/server.ts
@@ -310,6 +310,11 @@ export class SingleTsServer extends Disposable implements ITypeScriptServer {
 		command: string,
 		lowPriority?: boolean
 	): RequestQueueingType {
+		// console.log('tofu getQueueingType', command, lowPriority);
+		// if (command.includes('geterr')) {
+		// 	debugger;
+		// }
+
 		if (SingleTsServer.fenceCommands.has(command)) {
 			return RequestQueueingType.Fence;
 		}

--- a/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
+++ b/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
@@ -153,6 +153,8 @@ export default class TypeScriptServiceClientHost extends Disposable {
 		});
 
 		this.client.onTsServerStarted(() => {
+			// Does this fire on load?
+			// Not based on the breakpoint I set in the browser
 			this.triggerAllDiagnostics();
 		});
 

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -119,6 +119,7 @@ class CodeLensAdapter {
 	async provideCodeLenses(resource: URI, token: CancellationToken): Promise<extHostProtocol.ICodeLensListDto | undefined> {
 		const doc = this._documents.getDocument(resource);
 
+		// TOFU: This is where the membrane extension codelens provider is called
 		const lenses = await this._provider.provideCodeLenses(doc, token);
 		if (!lenses || token.isCancellationRequested) {
 			return undefined;


### PR DESCRIPTION
I don't think this is actionable (see [my notes in Slack thread](https://membrane-io.slack.com/archives/C1237JZQT/p1746110077164899?thread_ts=1746109665.434819&cid=C1237JZQT)), but I'm putting up a PR with a bunch of commented out console logs in case I want to reference it later.