### PR TITLE
Add aux bar toggle button to editor watermark

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorGroupWatermark.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupWatermark.ts
@@ -102,7 +102,6 @@ export class EditorGroupWatermark extends Disposable {
 		}, renderIcon(Codicon.chevronLeft));
 		this._register(this.contextKeyService.onDidChangeContext(e => {
 			if (e.affectsSome(new Set([AuxiliaryBarVisibleContext.key, MultipleEditorGroupsContext.key]))) {
-				console.log('tofu contextKeyService.onDidChangeContext', e);
 				const isAuxBarVisible = this.contextKeyService.contextMatchesRules(AuxiliaryBarVisibleContext);
 				const hasMultipleEditorGroups = this.contextKeyService.contextMatchesRules(MultipleEditorGroupsContext);
 				toggleButton.setAttribute('data-hide', (isAuxBarVisible || hasMultipleEditorGroups).toString());

--- a/src/vs/workbench/browser/parts/editor/editorGroupWatermark.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupWatermark.ts
@@ -11,7 +11,12 @@ import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { append, clearNode, $, h } from 'vs/base/browser/dom';
 import { KeybindingLabel } from 'vs/base/browser/ui/keybindingLabel/keybindingLabel';
-import { CommandsRegistry } from 'vs/platform/commands/common/commands';
+// MEMBRANE: add aux bar toggle icon button
+import { AuxiliaryBarVisibleContext, MultipleEditorGroupsContext } from 'vs/workbench/common/contextkeys';
+import { Codicon } from 'vs/base/common/codicons';
+import { CommandsRegistry, ICommandService } from 'vs/platform/commands/common/commands';
+import { renderIcon } from 'vs/base/browser/ui/iconLabel/iconLabels';
+// MEMBRANE: rm watermark hotkeys
 // import { ContextKeyExpr, ContextKeyExpression, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ContextKeyExpression, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { defaultKeybindingLabelStyles } from 'vs/platform/theme/browser/defaultStyles';
@@ -71,7 +76,8 @@ export class EditorGroupWatermark extends Disposable {
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
-		@IConfigurationService private readonly configurationService: IConfigurationService
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@ICommandService private readonly commandService: ICommandService,
 	) {
 		super();
 
@@ -79,6 +85,30 @@ export class EditorGroupWatermark extends Disposable {
 			h('.letterpress'),
 			h('.shortcuts@shortcuts'),
 		]);
+
+		// MEMBRANE: show aux bar toggle button
+		// 1. IF the aux bar is not visible
+		// 2. AND there are not multiple open editor groups
+		//		    (when there are multiple open editor groups, there can be a watermark empty editor in some cases)
+		//		    (and in that^ case, the watermark has an x icon to close it)
+		//		    (and the other open editors will handle aux bar toggle button via the editor tab bar actions)
+		// See also: editorTabsControl.ts
+		const hasMultipleEditorGroups = this.contextKeyService.contextMatchesRules(MultipleEditorGroupsContext);
+		const isAuxBarVisible = this.contextKeyService.contextMatchesRules(AuxiliaryBarVisibleContext);
+		const toggleButton = $('.toggle-aux-bar', {
+			title: 'Show Brane (AI) & Program Info',
+			onclick: () => this.commandService.executeCommand('workbench.action.toggleAuxiliaryBar'),
+			['data-hide']: isAuxBarVisible || hasMultipleEditorGroups,
+		}, renderIcon(Codicon.chevronLeft));
+		this._register(this.contextKeyService.onDidChangeContext(e => {
+			if (e.affectsSome(new Set([AuxiliaryBarVisibleContext.key, MultipleEditorGroupsContext.key]))) {
+				console.log('tofu contextKeyService.onDidChangeContext', e);
+				const isAuxBarVisible = this.contextKeyService.contextMatchesRules(AuxiliaryBarVisibleContext);
+				const hasMultipleEditorGroups = this.contextKeyService.contextMatchesRules(MultipleEditorGroupsContext);
+				toggleButton.setAttribute('data-hide', (isAuxBarVisible || hasMultipleEditorGroups).toString());
+			}
+		}));
+		append(elements.root, toggleButton);
 
 		append(container, elements.root);
 		this.shortcuts = elements.shortcuts;

--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -242,7 +242,7 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 			}
 		}));
 
-		// MEMBRANE: Additional toolbar items that appear to the right of the "..." overflow menu. This is basically a copy
+		// MEMBRANE: Additional toolbar items that appear in the top right of the editor. This is basically a copy
 		// of the above code for editorActionsToolbar but using MembraneEditorTitle instead of EditorTitle.
 		this.membraneActionsToolbar = this.editorActionsToolbarDisposables.add(this.instantiationService.createInstance(WorkbenchToolBar, container, {
 			actionViewItemProvider: action => this.actionViewItemProvider(action),

--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -268,6 +268,10 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 		this.editorGroupsService.onDidChangeActiveGroup(() => {
 			this.updateMembraneActions();
 		});
+		// Update when a file is opened
+		this.editorGroupsService.onDidActivateGroup(() => {
+			this.updateMembraneActions();
+		});
 
 		this.updateMembraneActions();
 	}

--- a/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
@@ -54,17 +54,41 @@
 	width: 50%;
 	max-height: 50%;
 	aspect-ratio: 1/1;
-	/* MEMRBANE: customize letterpress watermark */
+	/* MEMBRANE: customize letterpress watermark */
 	background-image: url('./membrane-letterpress-light.svg');
 	background-size: contain;
 	background-position-x: center;
 	background-repeat: no-repeat;
 }
 .monaco-workbench.vs-dark .part.editor > .content .editor-group-container .editor-group-watermark > .letterpress {
-	/* MEMRBANE: customize letterpress watermark */
+	/* MEMBRANE: customize letterpress watermark */
 	background-image: url('./membrane-letterpress-dark.svg');
 }
-	
+
+/* MEMBRANE: add aux bar toggle icon button */
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark > .toggle-aux-bar {
+	height: 30px;
+	width: 30px;
+	position: absolute;
+	right: 0;
+	top: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border: unset;
+	padding: unset;
+	background-color: unset;
+	cursor: pointer;
+
+	&[data-hide="true"] {
+		display: none;
+	}
+
+	&:hover {
+		background-color: var(--vscode-toolbar-hoverBackground);
+	}
+}
+
 /* 
  * MEMBRANE: rm hc letterpress watermark
 


### PR DESCRIPTION
See https://github.com/membrane-io/mnode/pull/609

@juancampa, re your idea to show the editor tab bar when there are no open files:
  - Editor tab bars are associated with editor groups
  - There are settings to show single/multiple or hide tabs for editor groups
  - But there isn’t an existing setting that would always show an editor tab bar
  - It is possible for there to be editor groups with no editors (I've run into this when the dashboard is in a split view and I refresh the page)
  - If we showed the editor tab bar for empty editors, we'd need to check position of each editor to conditionally render the tab bar or not, and there's already some logic that renders a close button (x icon) for an empty editor in split/grid view
  - So I added the toggle button to the watermark instead