### PR TITLE
AutoSave Off

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -267,7 +267,8 @@ configurationRegistry.registerConfiguration({
 				nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'files.autoSave.onFocusChange' }, "An editor with changes is automatically saved when the editor loses focus."),
 				nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'files.autoSave.onWindowChange' }, "An editor with changes is automatically saved when the window loses focus.")
 			],
-			'default': isWeb ? AutoSaveConfiguration.AFTER_DELAY : AutoSaveConfiguration.OFF,
+			// MEMBRANE: We do not want to auto save files because saves can deploy programs and we want deployments to be explicit.
+			'default': AutoSaveConfiguration.OFF,
 			'markdownDescription': nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'autoSave' }, "Controls [auto save](https://code.visualstudio.com/docs/editor/codebasics#_save-auto-save) of editors that have unsaved changes.", AutoSaveConfiguration.OFF, AutoSaveConfiguration.AFTER_DELAY, AutoSaveConfiguration.ON_FOCUS_CHANGE, AutoSaveConfiguration.ON_WINDOW_CHANGE, AutoSaveConfiguration.AFTER_DELAY),
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE
 		},

--- a/src/vs/workbench/services/filesConfiguration/common/filesConfigurationService.ts
+++ b/src/vs/workbench/services/filesConfiguration/common/filesConfigurationService.ts
@@ -13,7 +13,8 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IFilesConfiguration, AutoSaveConfiguration, HotExitConfiguration, FILES_READONLY_INCLUDE_CONFIG, FILES_READONLY_EXCLUDE_CONFIG, IFileStatWithMetadata, IFileService, IBaseFileStat, hasReadonlyCapability, IFilesConfigurationNode } from '../../../../platform/files/common/files.js';
 import { equals } from '../../../../base/common/objects.js';
 import { URI } from '../../../../base/common/uri.js';
-import { isWeb } from '../../../../base/common/platform.js';
+// MEMBRANE
+// import { isWeb } from '../../../../base/common/platform.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { ResourceGlobMatcher } from '../../../common/resources.js';
 import { GlobalIdleValue } from '../../../../base/common/async.js';
@@ -120,7 +121,8 @@ export class FilesConfigurationService extends Disposable implements IFilesConfi
 
 	declare readonly _serviceBrand: undefined;
 
-	private static readonly DEFAULT_AUTO_SAVE_MODE = isWeb ? AutoSaveConfiguration.AFTER_DELAY : AutoSaveConfiguration.OFF;
+	// MEMBRANE: We do not want to auto save files because saves can deploy programs and we want deployments to be explicit.
+	private static readonly DEFAULT_AUTO_SAVE_MODE = AutoSaveConfiguration.OFF;
 	private static readonly DEFAULT_AUTO_SAVE_DELAY = 1000;
 
 	private static readonly READONLY_MESSAGES = {


### PR DESCRIPTION
We noticed that programs were being auto‑saved with a 1000 ms delay when running in the web (isWeb), a behavior introduced in recent `vscode` updates. We disable auto‑save because saving can trigger deployments, and deployments should always be explicit (either manual or via an explicit “deploy on save” setting).