### PR TITLE
Demo Work

### DIFF
--- a/extensions/theme-defaults/themes/membrane_dark.json
+++ b/extensions/theme-defaults/themes/membrane_dark.json
@@ -4,6 +4,10 @@
 	"include": "./dark_modern.json",
 	"colors": {
 		"sash.hoverBorder": "#808080",
+		"editor.selectionBackground": "#ff800033",
+		"editor.hoverHighlightBackground": "#ff800033",
+		"editor.wordHighlightBackground": "#ff800033",
+		"editor.wordHighlightStrongBackground": "#ff800044",
 		"editorCodeLens.foreground": "#845bff",
 		"menu.selectionBackground": "#2a2a2a",
 		"menu.border": "#282828",

--- a/extensions/theme-defaults/themes/membrane_light.json
+++ b/extensions/theme-defaults/themes/membrane_light.json
@@ -4,6 +4,10 @@
 	"include": "./light_modern.json",
 	"colors": {
 		"sash.hoverBorder": "#999",
+		"editor.selectionBackground": "#ff800033",
+		"editor.hoverHighlightBackground": "#ff800033",
+		"editor.wordHighlightBackground": "#ff800033",
+		"editor.wordHighlightStrongBackground": "#ff800044",
 		"diffEditor.unchangedRegionBackground": "#efefef",
 		"activityBar.activeBorder": "#3c3c3c",
 		"activityBar.background": "#ddd",

--- a/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
+++ b/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
@@ -313,7 +313,8 @@ class Widget {
 		const underLineTop = anchor.top + anchor.height;
 		const heightAvailableUnderLine = ctx.viewportHeight - underLineTop;
 
-		const aboveTop = aboveLineTop - height;
+		// MEMBRANE: Clamp aboveTop to 0 so hover never escapes above the editor viewport
+		const aboveTop = Math.max(0, aboveLineTop - height);
 		const fitsAbove = (heightAvailableAboveLine >= height);
 		const belowTop = underLineTop;
 		const fitsBelow = (heightAvailableUnderLine >= height);

--- a/src/vs/editor/contrib/hover/browser/resizableContentWidget.ts
+++ b/src/vs/editor/contrib/hover/browser/resizableContentWidget.ts
@@ -15,7 +15,8 @@ const BOTTOM_HEIGHT = 24;
 
 export abstract class ResizableContentWidget extends Disposable implements IContentWidget {
 
-	readonly allowEditorOverflow: boolean = true;
+	// MEMBRANE: Keep hover within editor bounds to prevent overflow outside the visible area
+	readonly allowEditorOverflow: boolean = false;
 	readonly suppressMouseDown: boolean = false;
 
 	protected readonly _resizableNode = this._register(new ResizableHTMLElement());

--- a/src/vs/editor/contrib/multicursor/browser/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/browser/multicursor.ts
@@ -767,11 +767,12 @@ export class SelectHighlightsAction extends MultiCursorSelectionControllerAction
 			id: 'editor.action.selectHighlights',
 			label: nls.localize2('selectAllOccurrencesOfFindMatch', "Select All Occurrences of Find Match"),
 			precondition: undefined,
-			kbOpts: {
-				kbExpr: EditorContextKeys.focus,
-				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyL,
-				weight: KeybindingWeight.EditorContrib
-			},
+			// MEMBRANE: Disable Cmd+Shift+L keybinding
+			// kbOpts: {
+			// 	kbExpr: EditorContextKeys.focus,
+			// 	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyL,
+			// 	weight: KeybindingWeight.EditorContrib
+			// },
 			menuOpts: {
 				menuId: MenuId.MenubarSelectionMenu,
 				group: '3_multi',


### PR DESCRIPTION
This PR includes:
1. Disabled cmd+shift+l - commented out keybinding for "Select
All Occurrences" in multicursor.ts
2. Orange text selection - editor.selectionBackground: #ff800033
 in both Membrane themes
3. Orange hover highlight - editor.hoverHighlightBackground:
#ff800033 in both Membrane themes
4. Orange word highlight - editor.wordHighlightBackground and
editor.wordHighlightStrongBackground in both Membrane themes
5. Hover stays in editor bounds - allowEditorOverflow = false in
 resizableContentWidget.ts + clamped aboveTop to Math.max(0,
...) in contentWidgets.ts

